### PR TITLE
fixed num_est_agents in Python for subsets

### DIFF
--- a/respy/fortran/interface.py
+++ b/respy/fortran/interface.py
@@ -20,11 +20,11 @@ def resfort_interface(respy_obj, request, data_array=None):
     optim_paras, num_periods, edu_spec, is_debug, num_draws_emax, seed_emax, is_interpolated, \
     num_points_interp, is_myopic, tau, num_procs, num_agents_sim, num_draws_prob, \
     seed_prob, seed_sim, optimizer_options, optimizer_used, maxfun, precond_spec, \
-    file_sim, num_paras, num_types = dist_class_attributes(respy_obj, 'optim_paras',
+    file_sim, num_paras, num_types, num_agents_est = dist_class_attributes(respy_obj, 'optim_paras',
         'num_periods', 'edu_spec', 'is_debug', 'num_draws_emax', 'seed_emax', 'is_interpolated',
         'num_points_interp', 'is_myopic', 'tau', 'num_procs', 'num_agents_sim',
         'num_draws_prob', 'seed_prob', 'seed_sim', 'optimizer_options', 'optimizer_used',
-        'maxfun', 'precond_spec', 'file_sim', 'num_paras', 'num_types')
+        'maxfun', 'precond_spec', 'file_sim', 'num_paras', 'num_types', 'num_agents_est')
 
     if request == 'estimate':
         # Check that selected optimizer is in line with version of program.
@@ -40,7 +40,7 @@ def resfort_interface(respy_obj, request, data_array=None):
             is_myopic, edu_spec, is_debug, num_draws_prob, num_agents_sim,
             seed_prob, seed_emax, tau, num_procs, request, seed_sim, optimizer_options,
             optimizer_used, maxfun, num_paras, precond_spec, file_sim, data_array,
-            num_types)
+            num_types, num_agents_est)
 
     write_resfort_initialization(*args)
 
@@ -134,7 +134,7 @@ def write_resfort_initialization(optim_paras, is_interpolated, num_draws_emax, n
         num_points_interp, is_myopic, edu_spec, is_debug, num_draws_prob, num_agents_sim,
         seed_prob, seed_emax, tau, num_procs, request, seed_sim, optimizer_options,
         optimizer_used, maxfun, num_paras, precond_spec, file_sim, data_array,
-        num_types):
+        num_types, num_agents_est):
     """ Write out model request to hidden file .model.resfort.ini.
     """
 
@@ -225,14 +225,6 @@ def write_resfort_initialization(optim_paras, is_interpolated, num_draws_emax, n
         # ESTIMATION
         line = '{0:10d}\n'.format(maxfun)
         file_.write(line)
-
-        # We allow to estimate only on a subset of the requested number of agents to ease use of
-        # program, i.e. iteratively add different initial conditions. We need to handle the case
-        # where only a simulation in requested and thus data_array is None.
-        if data_array is not None:
-            num_agents_est = len(np.unique(data_array[:, 0]))
-        else:
-            num_agents_est = MISSING_INT
 
         line = '{0:10d}\n'.format(num_agents_est)
         file_.write(line)

--- a/respy/python/process/process_auxiliary.py
+++ b/respy/python/process/process_auxiliary.py
@@ -8,7 +8,8 @@ def check_dataset_est(data_frame, respy_obj):
     """ This routine runs some consistency checks on the simulated data frame.
     """
     # Distribute class attributes
-    num_periods, edu_spec = dist_class_attributes(respy_obj, 'num_periods', 'edu_spec')
+    num_periods, edu_spec, num_agents_est = dist_class_attributes(respy_obj, 'num_periods',
+        'edu_spec', 'num_agents_est')
 
     # Check that there are not missing values in any of the columns but for the wages information.
     for label in DATA_LABELS_EST:
@@ -83,6 +84,11 @@ def check_dataset_est(data_frame, respy_obj):
     def check_series_observations(group):
         np.testing.assert_equal(group['Period'].tolist(), list(range(group['Period'].max() + 1)))
     data_frame.groupby(level='Identifier').apply(check_series_observations)
+
+    # We need to ensure that the number of individuals requested for the estimation is also
+    # available. We do not enforce a strict equality here as a simulated dataset is also checked
+    # for its estimation suitability in general, i.e. before any constraints on initial conditions.
+    np.testing.assert_equal(data_frame['Identifier'].nunique() >= num_agents_est, True)
 
 
 def check_state_variables(agent):


### PR DESCRIPTION
The Python code was not working if the dataset, after restricting the initial conditions to only a subset, does not have at least the number of observations for the estimation requested by the user. To align the behavior across Fortran and Python, both are now using the as many observations as possible up the the requested number. The actual number of observations used in the estimation is written to the log file.
