### PR TITLE
increases allocated state_space

### DIFF
--- a/respy/tests/resources/f2py_interface.f90
+++ b/respy/tests/resources/f2py_interface.f90
@@ -444,7 +444,7 @@ SUBROUTINE wrapper_create_state_space(states_all_int, states_number_period_int, 
     !/* external objects        */
 
     INTEGER, INTENT(OUT)            :: mapping_state_idx_int(num_periods_int, num_periods_int, num_periods_int, min_idx_int, 4, num_types_int)
-    INTEGER, INTENT(OUT)            :: states_all_int(num_periods_int, 100000, 5)
+    INTEGER, INTENT(OUT)            :: states_all_int(num_periods_int, 150000, 5)
     INTEGER, INTENT(OUT)            :: states_number_period_int(num_periods_int)
     INTEGER, INTENT(OUT)            :: max_states_period_int
 


### PR DESCRIPTION
@janosg , this is just a very small edit to the code. As the f2py functions are now actually used for the SMM estimations, we need to allocate a much larger array for the serious estimation tasks. In testing, we only have much smaller models set up. I will collect all other edits required for the SMM integration that require changes to the core code in the next PR.