### PR TITLE
Add more features to linting and testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,17 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v1.3.4
+    hooks:
+    -   id: reorder-python-imports
+        files: '(\.py|wscript)$'
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    -   id: check-yaml
+        name: check-yaml - Validating .yaml Files
+-   repo: local
     hooks:
     - id: black
-      language_version: python3.6
+      name: Black - The Uncompromising Code Formatter
+      language: system
+      entry: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v1.3.4
     hooks:
     -   id: reorder-python-imports
-        files: '(\.py|wscript)$'
+        types: [python]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
@@ -22,4 +22,4 @@ repos:
       name: Black - The Uncompromising Code Formatter
       language: system
       entry: black
-      types: [python]
+      types: [python, pyi]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,17 @@ repos:
     hooks:
     -   id: check-yaml
         name: check-yaml - Validating .yaml Files
+    -   id: flake8
+        name: Flake8
+        description: This hook requirements.txtuns flake8.
+        entry: flake8
+        language: python
+        types: [python]
+        additional_dependencies: [flake8-alfred]
 -   repo: local
     hooks:
     - id: black
       name: Black - The Uncompromising Code Formatter
       language: system
       entry: black
+      types: [python]

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,11 @@ after_success:
     fi
 
 notifications:
-  slack: policy-lab:LkWqVb15dNvdLjMQOyacTXy6
-    on_success: change
 
-  email: false
+  slack:
+    rooms:
+      - oseconomics:NwY0nlxNsQh1WTEs7Y1acukS
+    on_success: change # default: always
+    on_failure: always # default: always
+
+ email: false

--- a/README.md
+++ b/README.md
@@ -1,9 +1,0 @@
-# respy
-
-``respy``  is an open-source Python package for the simulation and estimation of a prototypical finite-horizon discrete choice dynamic programming model. We build on the baseline model presented in:
-
-> Michael P. Keane, Kenneth I. Wolpin (1994). [The Solution and Estimation of Discrete Choice Dynamic Programming Models by Simulation and Interpolation: Monte Carlo Evidence](http://www.jstor.org/stable/2109768). *The Review of Economics and Statistics*, 76(4): 648-672.
-
-Please visit our [online documentation](http://respy.readthedocs.io/) for details.
-
-[![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)]()

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,13 @@
 name: respy
-
 dependencies:
   - python=3.6
   - numpy
   - pandas
   - statsmodels
-  - pytest
-  - pytest-xdist
   - scipy
-  - flake8
+  - pip:
+    - black
+    - flake8
+    - flake8-alfred
+    - pytest
+    - pytest-xdist

--- a/pyproyect.toml
+++ b/pyproyect.toml
@@ -1,15 +1,2 @@
 [tool.black]
 line-length = 88
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ install_command=pip install --no-binary respy -v -v -v  {opts} {packages}
 
 [flake8]
 enable-extensions = B1
+max-line-length = 88
 warn-symbols =
     numpy.tile = Numba performance warning! Replace with np.full(shape, value).
     numpy.empty = Numba performance warning! Replace with np.full(shape, value).

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,6 @@ install_command=pip install --no-binary respy -v -v -v  {opts} {packages}
 [flake8]
 enable-extensions = B1
 warn-symbols =
-    numpy.tile = Performance warning! Replace with np.full(shape, value)
+    numpy.tile = Numba performance warning! Replace with np.full(shape, value).
+    numpy.empty = Numba performance warning! Replace with np.full(shape, value).
+    numpy.dot = Numba performance warning! Replace np.dot(a, b) with a.dot(b).

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = py36
 skip_missing_interpreters=True
 
 [testenv]
-setenv =
-    PYTHONPATH = .
-deps=pytest
+deps=
+    pytest
+    pytest-pythonpath
 commands=py.test -m'not slow' -v -s
 install_command=pip install --no-binary respy -v -v -v  {opts} {packages}
 
@@ -15,3 +15,6 @@ warn-symbols =
     numpy.tile = Numba performance warning! Replace with np.full(shape, value).
     numpy.empty = Numba performance warning! Replace with np.full(shape, value).
     numpy.dot = Numba performance warning! Replace np.dot(a, b) with a.dot(b).
+
+[pytest]
+addopts = --doctest-modules

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ warn-symbols =
 
 [pytest]
 addopts = --doctest-modules
-norecursedirs = respy/*waf*
+norecursedirs =
+    respy/*waf*
+    respy/.*
 filterwarnings =
     ignore:`formatargspec` is deprecated
     ignore: Using or importing the ABCs from 'collections'

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,6 @@ warn-symbols =
 
 [pytest]
 addopts = --doctest-modules
+filterwarnings =
+    ignore:`formatargspec` is deprecated
+    ignore: Using or importing the ABCs from 'collections'

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,15 @@
 [tox]
 envlist = py36
 skip_missing_interpreters=True
+
 [testenv]
 setenv =
     PYTHONPATH = .
-deps=pytest      
+deps=pytest
 commands=py.test -m'not slow' -v -s
-install_command=pip install --no-binary respy -v -v -v  {opts} {packages} 
+install_command=pip install --no-binary respy -v -v -v  {opts} {packages}
+
+[flake8]
+enable-extensions = B1
+warn-symbols =
+    numpy.tile = Performance warning! Replace with np.full(shape, value)

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ warn-symbols =
 
 [pytest]
 addopts = --doctest-modules
+norecursedirs = respy/*waf*
 filterwarnings =
     ignore:`formatargspec` is deprecated
     ignore: Using or importing the ABCs from 'collections'


### PR DESCRIPTION
- changed black in .pre-commit as it looks for a python executable in C:\python3-6 on Windows. No Windows user has Python in this directory. Now, the local interpreter is used which means pre-commits only work with Python 3.6+
- pytest-pythonpath adds the current path to Pythonpath which renders setenv useless
- added reordering imports, needs check for sys.path in between
- added flake8-alfred for user defined warnings

### Todo

- [ ] Merge after CSV interface is integrated.