### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3:4.5.12
+
+# Prepare conda environment.
+COPY environment.yml .
+RUN conda update conda -y
+RUN conda init --all
+RUN conda env create
+
+# Install current version of respy.
+COPY . respy/
+RUN conda run --name respy pip install respy/
+
+CMD ["/bin/bash"]

--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -1,0 +1,51 @@
+Docker
+======
+
+We use Docker to create a reliable cross-platform environment in which our exhaustive
+test battery can run.
+
+Installation
+------------
+
+Download the appropriate Docker engine `here
+<https://hub.docker.com/search/?type=edition&offering=community>`_.
+
+.. warning:: You cannot install Docker on Windows 10 Home and on older MacOS. Choose the
+             `Docker Toolbox <https://docs.docker.com/toolbox/overview/>`_ instead.
+
+Build the image
+---------------
+
+In order to build the image with the current respy version in the repository, type
+
+.. code-block:: bash
+
+    $ docker build -t respy .
+
+To be clear, the image is built with the respy version in the directory using ``pip
+install .``. Unfortunately, this means that you have to rebuild the image every time you
+change something in the code. Since Docker creates layers during builds which are
+essentially snapshots after each statement in the ``Dockerfile``, this is not as costly
+as it sounds.
+
+Enter the the container interactively
+-------------------------------------
+
+Type
+
+.. code-block:: bash
+
+    $ docker run -it respy
+
+to enter the container and open a bash terminal. Then, switch to the correct environment
+with
+
+.. code-block:: bash
+
+    $ conda activate respy.
+
+If you want to exit the container, hit ``Ctrl + d`` or type
+
+.. code-block:: bash
+
+    $ exit.

--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -28,8 +28,8 @@ change something in the code. Since Docker creates layers during builds which ar
 essentially snapshots after each statement in the ``Dockerfile``, this is not as costly
 as it sounds.
 
-Enter the the container interactively
--------------------------------------
+Enter the container interactively
+---------------------------------
 
 Type
 

--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -59,3 +59,16 @@ If you want to exit the container, hit ``Ctrl + d`` or type
 .. code-block:: bash
 
     $ exit.
+
+Reclaiming space on disk
+------------------------
+
+Docker occupies a lot of space on your disk due to saving snapshots of the container,
+container itself, images, etc.. To reclaim the space, `prune
+<https://docs.docker.com/config/pruning/>`_ unused docker objects. Make sure that you do
+not accidentally delete valuable information.
+
+.. code-block:: bash
+
+    $ docker container prune  # Delete unused containers.
+    $ docker system prune     # Delete unused docker objects.

--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -13,20 +13,25 @@ Download the appropriate Docker engine `here
 .. warning:: You cannot install Docker on Windows 10 Home and on older MacOS. Choose the
              `Docker Toolbox <https://docs.docker.com/toolbox/overview/>`_ instead.
 
+
+
 Build the image
 ---------------
 
-In order to build the image with the current respy version in the repository, type
+In order to build the image with the current respy version in the repository, cd to the respy folder and type
 
 .. code-block:: bash
 
     $ docker build -t respy .
+
+.. warning:: On Linux systems you will need sudo permissions for `docker build`
 
 To be clear, the image is built with the respy version in the directory using ``pip
 install .``. Unfortunately, this means that you have to rebuild the image every time you
 change something in the code. Since Docker creates layers during builds which are
 essentially snapshots after each statement in the ``Dockerfile``, this is not as costly
 as it sounds.
+
 
 Enter the container interactively
 ---------------------------------
@@ -37,12 +42,17 @@ Type
 
     $ docker run -it respy
 
+
+.. warning:: On Linux systems you will need sudo permissions for `docker run`
+
 to enter the container and open a bash terminal. Then, switch to the correct environment
 with
 
 .. code-block:: bash
 
     $ conda activate respy.
+
+After entering the container you are in the home directory of a Linux system that contains the standard files and the `respy` folder.
 
 If you want to exit the container, hit ``Ctrl + d`` or type
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,12 @@ channels:
   - numba
 dependencies:
   - python=3.6
+  - pip=19.0.3
   - pandas=0.24
   - numba=0.43
   - numpy
-  - scipy>=0.19
-  - statsmodels=0.9
+  - scipy=1.2.1
+  - statsmodels=0.9.0
   - pip:
     - pytest
     - pytest-cov


### PR DESCRIPTION
This PR adds a ``Dockerfile`` to the repository for cross-platform testing.

There is some documentation on docker and how we use it in the documentation.

It might be possible to mount the respy repository in the Docker container and to make an editable install, but the usecase is probably very narrow. Therefore, we should stick to a solution where everything is fixed inside the container.