### PR TITLE
Add more information to package.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,19 +3,27 @@ respy
 
 .. image:: https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000
 
+.. image:: https://readthedocs.org/projects/respy/badge/?version=master
+    :target: https://respy.readthedocs.io/en/master/?badge=master
+    :alt: Documentation Status
+
 .. image:: https://travis-ci.org/OpenSourceEconomics/respy.svg?branch=master
     :target: https://travis-ci.org/OpenSourceEconomics/respy
 
 .. image:: https://ci.appveyor.com/api/projects/status/760nqwfsua0ej5u1/branch/master?svg=true
     :target: https://ci.appveyor.com/project/OpenSourceEconomics/respy/branch/master
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/ambv/black
+
 ``respy``  is an open-source Python package for the simulation and estimation of a
 prototypical finite-horizon discrete choice dynamic programming model. We build on the
 baseline model presented in:
 
-> Michael P. Keane, Kenneth I. Wolpin (1994). [The Solution and Estimation of Discrete
-> Choice Dynamic Programming Models by Simulation and Interpolation: Monte Carlo
-> Evidence](http://www.jstor.org/stable/2109768). *The Review of Economics and
-> Statistics*, 76(4): 648-672.
+    Keane, M. P. and  Wolpin, K. I. (1994). `The Solution and Estimation of Discrete
+    Choice Dynamic Programming Models by Simulation and Interpolation: Monte Carlo
+    Evidence <https://doi.org/10.2307/2109768>`_. *The Review of Economics and
+    Statistics*, 76(4): 648-672.
 
-Please visit our `online documentation <http://respy.readthedocs.io/>`_  for details.
+Please visit our `online documentation <https://respy.readthedocs.io/en/master/>`_ for
+details.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ DESCRIPTION = (
     "finite-horizon dynamic discrete choice model."
 )
 
-README = Path("README.rst").read()
+README = Path("README.rst").read_text()
 
 PROJECT_URLS = {
     "Bug Tracker": "https://github.com/OpenSourceEconomics/respy/issues",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pathlib import Path
 
 from setuptools import find_packages
 from setuptools import setup
@@ -41,6 +42,13 @@ class CustomBuildCommand(build_py):
         build_py.run(self)
 
 
+DESCRIPTION = (
+    "respy is a Python package for the simulation and estimation of a prototypical "
+    "finite-horizon dynamic discrete choice model."
+)
+
+README = Path("README.rst").read()
+
 PROJECT_URLS = {
     "Bug Tracker": "https://github.com/OpenSourceEconomics/respy/issues",
     "Documentation": "https://respy.readthedocs.io/en/latest",
@@ -65,10 +73,7 @@ def setup_package():
             ]
         },
         version="1.2.0",
-        description=(
-            "respy is a Python package for the simulation and estimation of a "
-            "prototypical finite-horizon dynamic discrete choice model."
-        ),
+        description=DESCRIPTION,
         author="Philipp Eisenhauer",
         author_email="eisenhauer@policy-lab.org",
         url="https://respy.readthedocs.io/en/latest/",
@@ -87,7 +92,7 @@ def setup_package():
             "pandas>=0.24",
             "scipy>=0.19",
             "statsmodels>=0.9",
-            "pytest>=3.0",
+            "pytest>=4.0",
             "pyaml",
         ],
         cmdclass={"build_py": CustomBuildCommand, "develop": CustomDevelopCommand},


### PR DESCRIPTION
The major contribution is that there was no project description on PyPI (https://pypi.org/project/respy/) before. Now, we use the content of the README. PyPI only accepts a subset of rst syntax for the description, but this is already validated with pre-commit hook restructuredtext_lint.