### PR TITLE
Limit Travis-CI to one build for each PR commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ language:
 python:
     - 3.6
 
+# The tests run only if it is an PR or if a tag is pushed. This should prevent duplicate
+# builds with pr and push. We cannot disable push as it also disables deployment via
+# tags.
+if: type != push OR tag IS present
+
 before_install:
     - sudo apt-get update
 


### PR DESCRIPTION
This is an old problem which has been insufficiently addressed by Travis. Travis-CI normally starts two builds for each commit on a PR, one for the commit on the PR and one automatic merge commit with the target branch. We had limited the runs in the configuration on Travis, but this also disabled deployment via tags as the tagged commit was not checked on Travis. Now, here is the solution using Travis [build conditions](https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#testing-conditions).