### PR TITLE
Reenable testing for MacOS on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
 
-  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION tox-conda -c conda-forge
+  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION tox-conda numpy mkl -c defaults -c conda-forge
     displayName: Create Anaconda environment
 
   - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -31,8 +31,8 @@ jobs:
     matrix:
       Python36:
         python.version: "3.6"
-      # Python37:
-      #   python.version: "3.7"
+      Python37:
+        python.version: "3.7"
 
   steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         additional_dependencies: [
             flake8-bugbear, flake8-builtins, flake8-comprehensions, flake8-docstrings,
             flake8-eradicate, flake8-print, flake8-rst-docstrings, flake8-todo,
-            pep8-naming,
+            pep8-naming, pydocstyle<4.0.0,
         ]
         files: 'respy/.*'  # We start with a subfolder and extend the scope later.
 -   repo: local

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - estimagic>=0.0.6
   - jupyterlab
   - matplotlib>=3.0.0
+  - mkl
   - nbsphinx=0.4.2
   - numba=0.43.1
   - numpydoc

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ basepython = python
 conda_deps =
     codecov
     estimagic >= 0.0.6
+    mkl
     numba >= 0.43
     pandas >= 0.24
     scipy >= 1.2.1


### PR DESCRIPTION
* Date you used respy PyPackage: 17.07.19
* respy version used, if any: > 1.2.1
* Python version, if any: 3.7
* Operating System: Windows

### Current Behavior

Testing for MacOS fails on Azure Pipelines. This PR can be updated from time to time and we can check whether testing will work at some point. I assume it has something to do with conda and the packages. This might go away at some point.