### PR TITLE
Add pyupgrade to pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
     -   id: check-yaml
     -   id: check-merge-conflict
     -   id: debug-statements
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v1.21.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v1.4.0
     hooks:

--- a/respy/pre_processing/specification_helpers.py
+++ b/respy/pre_processing/specification_helpers.py
@@ -71,8 +71,8 @@ def _type_shift_template(n_types):
     to_concat = []
     for type_ in range(2, n_types + 1):
         for choice in ["a", "b", "edu", "home"]:
-            ind = ("type_shift", "type_{}_in_{}".format(type_, choice))
-            comment = "deviation for type {} from type 1 in {}".format(type_, choice)
+            ind = ("type_shift", f"type_{type_}_in_{choice}")
+            comment = f"deviation for type {type_} from type 1 in {choice}"
             dat = [0, False, np.nan, np.nan, comment]
             to_concat.append(_base_row(index_tuple=ind, data=dat))
     return pd.concat(to_concat, axis=0, sort=False)


### PR DESCRIPTION
* Date you used respy PyPackage: 19.07.2019
* respy version used, if any: > 1.2.1
* Python version, if any: 3.7
* Operating System: Windows

This PR adds ``pyupgrade`` to pre-commit hooks which automatically upgrades Python syntax to 3.6+.