### PR TITLE
Remove adjustment of periods in estimation.

### DIFF
--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -428,13 +428,4 @@ def _adjust_options_for_estimation(options, df):
             options["choices"][choice].pop("share")
             options["choices"][choice].pop("lagged")
 
-        # Adjust the number of periods.
-        if not options["n_periods"] == df.Period.max() + 1:
-            warnings.warn(
-                f"The number of periods differs between data, {df.Period.max()}, and "
-                f"options, {options['n_periods']}. The options are ingored.",
-                category=UserWarning,
-            )
-            options["n_periods"] = df.Period.max() + 1
-
     return options


### PR DESCRIPTION
* respy version used, if any: after 1.2.1
* Python version, if any: 3.7
* Operating System: any

### Current Behavior

While implementing Keane and Wolpin (1997) we added an a function which adjusts the option and prints warnings for the user. At that time, I thought adjusting the number of periods to the maximum number in the data might be computationally beneficial.

But, reducing the periods also decreases the value functions as discounted utility from later periods is simply cut off or set to zero.

### Solution / Implementation

Simply remove it.