### PR TITLE
Return simulated data for Keane and Wolpin (1994).

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -51,36 +51,36 @@ jobs:
       tox -e pytest
     displayName: Run pytest.
 
-- job:
-  displayName: MacOS
-  pool:
-    vmImage: "macOS-latest"
-  strategy:
-    matrix:
-      Python36:
-        python.version: "3.6"
-      Python37:
-        python.version: "3.7"
+# - job:
+#   displayName: MacOS
+#   pool:
+#     vmImage: "macOS-latest"
+#   strategy:
+#     matrix:
+#       Python36:
+#         python.version: "3.6"
+#       Python37:
+#         python.version: "3.7"
 
-  steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+#   steps:
+#   - bash: echo "##vso[task.prependpath]$CONDA/bin"
+#     displayName: Add conda to PATH
 
-  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
-  # directory. We need to take ownership if we want to update conda or install packages
-  # globally.
-  - bash: sudo chown -R $USER $CONDA
-    displayName: Take ownership of conda installation
+#   # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+#   # directory. We need to take ownership if we want to update conda or install packages
+#   # globally.
+#   - bash: sudo chown -R $USER $CONDA
+#     displayName: Take ownership of conda installation
 
-  - bash: |
-      conda clean --index-cache --yes
-      conda clean --all --yes
-    displayName: Reset index-cache and clean conda.
+#   - bash: |
+#       conda clean --index-cache --yes
+#       conda clean --all --yes
+#     displayName: Reset index-cache and clean conda.
 
-  - bash: conda create --yes --quiet --name respy python=$PYTHON_VERSION tox-conda -c conda-forge
-    displayName: Create Anaconda environment
+#   - bash: conda create --yes --quiet --name respy python=$PYTHON_VERSION tox-conda -c conda-forge
+#     displayName: Create Anaconda environment
 
-  - bash: |
-      source activate respy
-      tox -e pytest
-    displayName: Run pytest.
+#   - bash: |
+#       source activate respy
+#       tox -e pytest
+#     displayName: Run pytest.

--- a/development/documentation/scalability/run_single_scalability_exercise.py
+++ b/development/documentation/scalability/run_single_scalability_exercise.py
@@ -3,8 +3,6 @@ import json
 import os
 import sys
 
-import respy.interface
-
 
 def main():
     """Evaluate the criterion function multiple times for a scalability report.
@@ -35,7 +33,7 @@ def main():
     import respy as rp
 
     # Get model
-    options, params = respy.interface.get_example_model(model, with_data=False)
+    options, params = rp.get_example_model(model, with_data=False)
 
     # Simulate the data
     simulate = rp.get_simulate_func(params, options)

--- a/development/documentation/scalability/run_single_scalability_exercise.py
+++ b/development/documentation/scalability/run_single_scalability_exercise.py
@@ -3,6 +3,8 @@ import json
 import os
 import sys
 
+import respy.interface
+
 
 def main():
     """Evaluate the criterion function multiple times for a scalability report.
@@ -33,7 +35,7 @@ def main():
     import respy as rp
 
     # Get model
-    options, params, _ = rp.get_example_model(model)
+    options, params = respy.interface.get_example_model(model, with_data=False)
 
     # Simulate the data
     simulate = rp.get_simulate_func(params, options)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,16 @@
 API
 ===
 
+interface
+---------
+
+.. currentmodule:: respy.interface
+
+.. autosummary::
+    :toctree: _generated/
+
+    get_example_model
+
 state_space
 -----------
 

--- a/docs/getting_started/tutorial-kw-94-simulation.ipynb
+++ b/docs/getting_started/tutorial-kw-94-simulation.ipynb
@@ -51,7 +51,7 @@
    "outputs": [],
    "source": [
     "# Load example model and convert parameter and options to model attributes.\n",
-    "params, options, _ = rp.get_example_model(\"kw_94_one\")"
+    "params, options = rp.get_example_model(\"kw_94_one\", with_data=False)"
    ]
   },
   {
@@ -384,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/tutorial-kw-97-simulation.ipynb
+++ b/docs/getting_started/tutorial-kw-97-simulation.ipynb
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "params, options, _ = rp.get_example_model(\"kw_97_base\")\n",
+    "params, options = rp.get_example_model(\"kw_97_base\", with_data=False)\n",
     "\n",
     "options[\"n_periods\"] = 50\n",
     "\n",
@@ -109,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "params, options, _ = rp.get_example_model(\"kw_97_extended\")\n",
+    "params, options = rp.get_example_model(\"kw_97_extended\", with_data=False)\n",
     "\n",
     "simulate = rp.get_simulate_func(params, options)\n",
     "df = simulate(params)"
@@ -182,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/tutorial.ipynb
+++ b/docs/getting_started/tutorial.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "In order to define a model, ``respy`` relies on two objects - parameters and options. The difference between the two is that parameters are affected by the optimization whereas options stay the same. Here, only some parameters and options are explained. For a complete overview on parameters and options, visit the section [model specification](../software/model-specification.rst).\n",
     "\n",
-    "As an example, we turn to the first model of Keane and Wolpin (1994). The following function returns the parameters and options and the original dataset used by the authors. Right now, we do not need the data and discard it by assigning it to ``_``."
+    "As an example, we turn to the first model of Keane and Wolpin (1994). The following function returns the parameters and options and the original dataset used by the authors. Passing ``with_data=False`` prevents the function to return a data set."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, options, _ = rp.get_example_model(\"kw_94_one\")"
+    "params, options = rp.get_example_model(\"kw_94_one\", with_data=False)"
    ]
   },
   {
@@ -292,22 +292,6 @@
    "source": [
     "options['estimation_tau'] = 50\n",
     "options['estimation_draws'] = 2000"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The dataset is almost in the correct format for the estimation. Note that lagged choices for the first period are missing. As a preliminary fix, we assume that all individuals were in school the previous period which is not unreasonable for individuals with age 16."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.Lagged_Choice = df.Lagged_Choice.fillna(\"edu\")"
    ]
   },
   {
@@ -2197,7 +2181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/respy/__init__.py
+++ b/respy/__init__.py
@@ -15,8 +15,8 @@ import sys
 import pytest
 
 from respy.config import ROOT_DIR
+from respy.interface import get_example_model  # noqa: F401
 from respy.likelihood import get_crit_func  # noqa: F401
-from respy.shared import get_example_model  # noqa: F401
 from respy.simulate import get_simulate_func  # noqa: F401
 from respy.solve import solve  # noqa: F401
 

--- a/respy/interface.py
+++ b/respy/interface.py
@@ -1,0 +1,29 @@
+import warnings
+
+import pandas as pd
+import yaml
+
+from respy.config import EXAMPLE_MODELS
+from respy.config import TEST_RESOURCES_DIR
+from respy.data import create_kw_97
+from respy.simulate import get_simulate_func
+
+
+def get_example_model(model, with_data=True):
+    assert model in EXAMPLE_MODELS, f"{model} is not in {EXAMPLE_MODELS}."
+
+    options = yaml.safe_load((TEST_RESOURCES_DIR / f"{model}.yaml").read_text())
+    params = pd.read_csv(
+        TEST_RESOURCES_DIR / f"{model}.csv", index_col=["category", "name"]
+    )
+
+    if "kw_97" in model and with_data:
+        df = (create_kw_97(),)
+    elif "kw_94" in model and with_data:
+        simulate = get_simulate_func(params, options)
+        df = (simulate(params),)
+    else:
+        df = ()
+        warnings.warn(f"No data available for model '{model}'.", category=UserWarning)
+
+    return (params, options) + df

--- a/respy/interface.py
+++ b/respy/interface.py
@@ -34,6 +34,9 @@ def get_example_model(model, with_data=True):
         df = (simulate(params),)
     else:
         df = ()
-        warnings.warn(f"No data available for model '{model}'.", category=UserWarning)
+        if with_data:
+            warnings.warn(
+                f"No data available for model '{model}'.", category=UserWarning
+            )
 
     return (params, options) + df

--- a/respy/interface.py
+++ b/respy/interface.py
@@ -10,6 +10,16 @@ from respy.simulate import get_simulate_func
 
 
 def get_example_model(model, with_data=True):
+    """Return parameters, options and data (optional) of an example model.
+
+    Parameters
+    ----------
+    model : str
+        Use arbitrary string to see all available models in traceback.
+    with_data : bool
+        Whether the accompanying data set should be returned.
+
+    """
     assert model in EXAMPLE_MODELS, f"{model} is not in {EXAMPLE_MODELS}."
 
     options = yaml.safe_load((TEST_RESOURCES_DIR / f"{model}.yaml").read_text())

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -2,7 +2,6 @@ import warnings
 from functools import partial
 
 import numpy as np
-import pandas as pd
 from numba import guvectorize
 
 from respy.conditional_draws import create_draws_and_log_prob_wages
@@ -12,10 +11,9 @@ from respy.pre_processing.model_processing import process_params_and_options
 from respy.shared import aggregate_keane_wolpin_utility
 from respy.shared import clip
 from respy.shared import create_base_draws
-from respy.shared import downcast_to_smallest_dtype
+from respy.shared import create_type_covariates
 from respy.shared import predict_multinomial_logit
 from respy.solve import solve_with_backward_induction
-from respy.state_space import create_base_covariates
 from respy.state_space import StateSpace
 
 
@@ -370,23 +368,6 @@ def _convert_choice_variables_from_categorical_to_codes(df, options):
     df.lagged_choice = df.lagged_choice.replace(choices_to_codes).astype(np.uint8)
 
     return df
-
-
-def create_type_covariates(df, options):
-    """Create covariates to predict type probabilities.
-
-    In the simulation, the covariates are needed to predict type probabilities and
-    assign types to simulated individuals. In the estimation, covariates are necessary
-    to weight the probability of observations by type probabilities.
-
-    """
-    covariates = create_base_covariates(df, options["covariates"])
-
-    all_data = pd.concat([covariates, df], axis="columns", sort=False)
-
-    all_data = all_data[options["type_covariates"]].apply(downcast_to_smallest_dtype)
-
-    return all_data.to_numpy()
 
 
 def _process_estimation_data(df, options):

--- a/respy/shared.py
+++ b/respy/shared.py
@@ -1,3 +1,9 @@
+"""Contains functions which are shared across other modules.
+
+This module should only import from other packages or modules of respy which also do not
+import from respy itself. This is to prevent circular imports.
+
+"""
 import numpy as np
 import pandas as pd
 from numba import guvectorize

--- a/respy/shared.py
+++ b/respy/shared.py
@@ -1,18 +1,11 @@
-import warnings
-
 import numpy as np
 import pandas as pd
-import yaml
 from numba import guvectorize
 from numba import njit
 from numba import vectorize
 
-from respy import data as rp_data
-from respy.config import EXAMPLE_MODELS
 from respy.config import HUGE_FLOAT
 from respy.config import INADMISSIBILITY_PENALTY
-from respy.config import TEST_RESOURCES_DIR
-from respy.simulate import get_simulate_func
 
 
 @njit
@@ -118,26 +111,6 @@ def transform_disturbances(draws, shocks_mean, shocks_cholesky, n_wages):
     return draws_transformed
 
 
-def get_example_model(model):
-    assert model in EXAMPLE_MODELS, f"{model} is not in {EXAMPLE_MODELS}."
-
-    options = yaml.safe_load((TEST_RESOURCES_DIR / f"{model}.yaml").read_text())
-    params = pd.read_csv(
-        TEST_RESOURCES_DIR / f"{model}.csv", index_col=["category", "name"]
-    )
-
-    if "kw_97" in model:
-        df = rp_data.create_kw_97()
-    elif "kw_94" in model:
-        simulate = get_simulate_func(params, options)
-        df = simulate(params)
-    else:
-        df = None
-        warnings.warn(f"No data available for model '{model}'.", category=UserWarning)
-
-    return params, options, df
-
-
 def generate_column_labels_estimation(options):
     labels = (
         ["Identifier", "Period", "Choice", "Wage"]
@@ -230,3 +203,47 @@ def downcast_to_smallest_dtype(series):
                 pass
 
     return series.astype(min_dtype)
+
+
+def create_type_covariates(df, options):
+    """Create covariates to predict type probabilities.
+
+    In the simulation, the covariates are needed to predict type probabilities and
+    assign types to simulated individuals. In the estimation, covariates are necessary
+    to weight the probability of observations by type probabilities.
+
+    """
+    covariates = create_base_covariates(df, options["covariates"])
+
+    all_data = pd.concat([covariates, df], axis="columns", sort=False)
+
+    all_data = all_data[options["type_covariates"]].apply(downcast_to_smallest_dtype)
+
+    return all_data.to_numpy()
+
+
+def create_base_covariates(states, covariates_spec):
+    """Create set of covariates for each state.
+
+    Parameters
+    ----------
+    states : pandas.DataFrame
+        DataFrame with shape (n_states, n_choices_w_exp + 3) containing period,
+        experiences, choice_lagged and type of each state.
+    covariates_spec : dict
+        Keys represent covariates and values are strings passed to ``df.eval``.
+
+    Returns
+    -------
+    covariates : pandas.DataFrame
+        DataFrame with shape (n_states, n_covariates).
+
+    """
+    covariates = states.copy()
+
+    for covariate, definition in covariates_spec.items():
+        covariates[covariate] = covariates.eval(definition)
+
+    covariates = covariates.drop(columns=states.columns)
+
+    return covariates

--- a/respy/shared.py
+++ b/respy/shared.py
@@ -12,6 +12,7 @@ from respy.config import EXAMPLE_MODELS
 from respy.config import HUGE_FLOAT
 from respy.config import INADMISSIBILITY_PENALTY
 from respy.config import TEST_RESOURCES_DIR
+from respy.simulate import get_simulate_func
 
 
 @njit
@@ -128,7 +129,8 @@ def get_example_model(model):
     if "kw_97" in model:
         df = rp_data.create_kw_97()
     elif "kw_94" in model:
-        df = rp_data.create_kw_94()
+        simulate = get_simulate_func(params, options)
+        df = simulate(params)
     else:
         df = None
         warnings.warn(f"No data available for model '{model}'.", category=UserWarning)

--- a/respy/simulate.py
+++ b/respy/simulate.py
@@ -5,10 +5,10 @@ import pandas as pd
 from numba import guvectorize
 
 from respy.config import HUGE_FLOAT
-from respy.likelihood import create_type_covariates
 from respy.pre_processing.model_processing import process_params_and_options
 from respy.shared import aggregate_keane_wolpin_utility
 from respy.shared import create_base_draws
+from respy.shared import create_type_covariates
 from respy.shared import generate_column_labels_simulation
 from respy.shared import predict_multinomial_logit
 from respy.shared import transform_disturbances

--- a/respy/state_space.py
+++ b/respy/state_space.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from respy.config import HUGE_FLOAT
 from respy.pre_processing.model_processing import process_params_and_options
+from respy.shared import create_base_covariates
 from respy.shared import create_base_draws
 from respy.shared import downcast_to_smallest_dtype
 
@@ -522,33 +523,6 @@ def _create_choice_covariates(covariates_df, states_df, params, options):
 
     for key, val in covariates.items():
         covariates[key] = np.ascontiguousarray(val)
-
-    return covariates
-
-
-def create_base_covariates(states, covariates_spec):
-    """Create set of covariates for each state.
-
-    Parameters
-    ----------
-    states : pandas.DataFrame
-        DataFrame with shape (n_states, n_choices_w_exp + 3) containing period,
-        experiences, choice_lagged and type of each state.
-    covariates_spec : dict
-        Keys represent covariates and values are strings passed to ``df.eval``.
-
-    Returns
-    -------
-    covariates : pandas.DataFrame
-        DataFrame with shape (n_states, n_covariates).
-
-    """
-    covariates = states.copy()
-
-    for covariate, definition in covariates_spec.items():
-        covariates[covariate] = covariates.eval(definition)
-
-    covariates = covariates.drop(columns=states.columns)
 
     return covariates
 

--- a/respy/tests/test_model.py
+++ b/respy/tests/test_model.py
@@ -3,11 +3,11 @@ import numpy as np
 import pytest
 from deepdiff import DeepDiff
 
+from respy import get_example_model
 from respy.config import EXAMPLE_MODELS
 from respy.likelihood import get_crit_func
 from respy.pre_processing.model_checking import validate_options
 from respy.pre_processing.model_processing import process_params_and_options
-from respy.shared import get_example_model
 from respy.tests.random_model import generate_random_model
 from respy.tests.random_model import simulate_truncated_data
 from respy.tests.utils import process_model_or_seed
@@ -43,7 +43,7 @@ def test_invariance_to_order_of_initial_schooling_levels(model_or_seed):
     bound_constr = {"max_edu_start": 10}
 
     if isinstance(model_or_seed, str):
-        params, options, _ = get_example_model(model_or_seed)
+        params, options = get_example_model(model_or_seed, with_data=False)
     else:
         np.random.seed(model_or_seed)
         params, options = generate_random_model(bound_constr=bound_constr)

--- a/respy/tests/utils.py
+++ b/respy/tests/utils.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-from respy.shared import get_example_model
+from respy import get_example_model
 from respy.tests.random_model import generate_random_model
 
 
 def process_model_or_seed(model_or_seed, **kwargs):
     if isinstance(model_or_seed, str):
-        params, options, _ = get_example_model(model_or_seed)
+        params, options = get_example_model(model_or_seed, with_data=False)
     else:
         np.random.seed(model_or_seed)
         params, options = generate_random_model(**kwargs)

--- a/respy/tests/utils.py
+++ b/respy/tests/utils.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-from respy import get_example_model
+import respy as rp
 from respy.tests.random_model import generate_random_model
 
 
 def process_model_or_seed(model_or_seed, **kwargs):
     if isinstance(model_or_seed, str):
-        params, options = get_example_model(model_or_seed, with_data=False)
+        params, options = rp.get_example_model(model_or_seed, with_data=False)
     else:
         np.random.seed(model_or_seed)
         params, options = generate_random_model(**kwargs)


### PR DESCRIPTION
* respy version used, if any: 2.0.0-dev
* Python version, if any: any
* Operating System: any

### Current Behavior

Requesting a Keane and Wolpin (1994) model does return the truncated data of Keane and Wolpin (1997).

### Desired Bahavior

To align the package and the data, the function should return simulated data.

### Changes

- [x] New module ``interface.py`` so that ``shared.py`` does not import anything from respy which was a major source of circular imports.
- [x] ``get_example_model()`` does return data by default, but it can be switched off with ``with_data=False`` which also speeds up testing for us.