### PR TITLE
Fix respy under MacOS.

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -54,39 +54,39 @@ jobs:
       tox -e pytest
     displayName: Run pytest.
 
-# - job:
-#   displayName: MacOS
-#   pool:
-#     vmImage: "macOS-latest"
-#   strategy:
-#     matrix:
-#       Python36:
-#         python.version: "3.6"
-#       Python37:
-#         python.version: "3.7"
+- job:
+  displayName: MacOS
+  pool:
+    vmImage: "macOS-latest"
+  strategy:
+    matrix:
+      Python36:
+        python.version: "3.6"
+      Python37:
+        python.version: "3.7"
 
-#   steps:
-#   - bash: echo "##vso[task.prependpath]$CONDA/bin"
-#     displayName: Add conda to PATH
+  steps:
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
 
-#   # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
-#   # directory. We need to take ownership if we want to update conda or install packages
-#   # globally.
-#   - bash: sudo chown -R $USER $CONDA
-#     displayName: Take ownership of conda installation
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+  # directory. We need to take ownership if we want to update conda or install packages
+  # globally.
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
 
-#   - bash: conda update conda --yes --quiet
-#     displayName: Update conda.
+  - bash: conda update conda --yes --quiet
+    displayName: Update conda.
 
-#   - bash: |
-#       conda clean --index-cache --yes
-#       conda clean --all --yes
-#     displayName: Reset index-cache and clean conda.
+  - bash: |
+      conda clean --index-cache --yes
+      conda clean --all --yes
+    displayName: Reset index-cache and clean conda.
 
-#   - bash: conda create --yes --quiet --name respy python=$PYTHON_VERSION tox-conda -c conda-forge
-#     displayName: Create Anaconda environment
+  - bash: conda create --yes --quiet --name respy python=$PYTHON_VERSION tox-conda -c conda-forge
+    displayName: Create Anaconda environment
 
-#   - bash: |
-#       source activate respy
-#       tox -e pytest
-#     displayName: Run pytest.
+  - bash: |
+      source activate respy
+      tox -e pytest
+    displayName: Run pytest.

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,8 +39,7 @@ jobs:
         python.version: "3.7"
 
   steps:
-  - powershell: |
-      Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH.
 
   - powershell: conda update conda --yes --quiet

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,12 +46,7 @@ jobs:
   - powershell: conda update conda --yes --quiet
     displayName: Update conda.
 
-  - bash: |
-      conda clean --index-cache --yes
-      conda clean --all --yes
-    displayName: Reset index-cache and clean conda.
-
-  - powershell: conda env create
+  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION tox-conda numpy scipy -c conda-forge
     displayName: Create Anaconda environment.
 
   - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       conda clean --all --yes
     displayName: Reset index-cache and clean conda.
 
-  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION numpy tox-conda -c conda-forge
+  - powershell: conda env create
     displayName: Create Anaconda environment.
 
   - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,6 +46,11 @@ jobs:
   - powershell: conda update conda --yes --quiet
     displayName: Update conda.
 
+  - bash: |
+      conda clean --index-cache --yes
+      conda clean --all --yes
+    displayName: Reset index-cache and clean conda.
+
   - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION tox-conda -c conda-forge
     displayName: Create Anaconda environment.
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       conda clean --all --yes
     displayName: Reset index-cache and clean conda.
 
-  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION tox-conda -c conda-forge
+  - powershell: conda create --yes --quiet --name respy python=$env:PYTHON_VERSION numpy tox-conda -c conda-forge
     displayName: Create Anaconda environment.
 
   - script: |

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,5 @@
 name: respy
 channels:
-  - numba
-  - defaults
   - conda-forge
   - janosg
 dependencies:
@@ -9,6 +7,7 @@ dependencies:
   - pip
   - click
   - codecov
+  - conda-build
   - doc8
   - deepdiff
   - estimagic>=0.0.9
@@ -25,7 +24,7 @@ dependencies:
   - pytest-xdist
   - restructuredtext_lint
   - scipy
-  - Sphinx
+  - sphinx
   - sphinx-autobuild
   - tox-conda
   - pip:

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,6 @@ conda_channels =
     janosg
 deps =
     apprise
-install_command =
-    pip install {packages}
 commands =
     pytest {posargs} --cov=respy -vvv
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,6 @@ conda_deps =
     pytest-cov
     pytest-xdist
 conda_channels =
-    numba
-    defaults
     conda-forge
     janosg
 deps =


### PR DESCRIPTION
* respy version used, if any: 2.0.0dev
* Python version, if any: any
* Operating System: any

### Current Behavior

The current channel mix of ``numba``, ``defaults``, ``conda-forge`` and ``janosg`` causes headaches on MacOS. Actually, it is a common problem that conda seems to be confused if multiple channels with different priorities are mixed.

### Solution

- Remove ``numba`` and ``defaults`` from the channel priority list and solely depend on ``conda-forge`` and ``janosg``.