### PR TITLE
Make the calculation of choice probabilities more robust.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - doc8
   - estimagic>=0.0.14
   - jupyterlab
+  - line_profiler
   - matplotlib
   - mkl
   - nbsphinx=0.4.2
@@ -23,6 +24,7 @@ dependencies:
   - pytest-xdist
   - restructuredtext_lint
   - scipy
+  - snakeviz
   - sphinx
   - sphinx-autobuild
   - tox-conda

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -379,11 +379,11 @@ def simulate_log_probability_of_individuals_observed_choice(
 
     value_functions = np.zeros((n_draws, n_choices))
 
-    prob_choice = 0.0
+    prob_choice = 0
 
     for i in range(n_draws):
 
-        max_value_functions = 0.0
+        max_value_functions = 0
 
         for j in range(n_choices):
             value_function, _ = aggregate_keane_wolpin_utility(
@@ -400,12 +400,12 @@ def simulate_log_probability_of_individuals_observed_choice(
             if value_function > max_value_functions:
                 max_value_functions = value_function
 
-        sum_smooth_values = 0.0
+        sum_smooth_values = 0
 
         for j in range(n_choices):
             val_exp = np.exp((value_functions[i, j] - max_value_functions) / tau)
 
-            val_clipped = clip(val_exp, 0.0, HUGE_FLOAT)
+            val_clipped = clip(val_exp, 0, HUGE_FLOAT)
 
             value_functions[i, j] = val_clipped
             sum_smooth_values += val_clipped

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -3,8 +3,6 @@ from functools import partial
 
 import numba as nb
 import numpy as np
-
-from numba import guvectorize
 from scipy.special import logsumexp
 from scipy.special import softmax
 

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -325,7 +325,7 @@ def _internal_log_like_obs(
 
 
 @nb.njit
-def log_softmax_i(x, i, k=1):
+def log_softmax_i(x, i, tau=1):
     """Calculate log probability of a soft maximum for index ``i``.
 
     The log softmax function is essentially
@@ -347,13 +347,14 @@ def log_softmax_i(x, i, k=1):
     ``exp(-inf) = 0`` at its lowest value. Only infinite inputs can cause an invalid
     output.
 
-    The smoothing parameter controls the smoothness of the function. For ``k`` close to
-    1, the function is more similar to ``max(x)`` and the derivatives of the functions
-    grow to infinity. As ``k`` grows, the smoothed maximum is bigger than the actual
-    maximum and derivatives diminish. See [1]_ for more information on the smoothing
-    factor ``k``. Note that the post covers the inverse of the smoothing factor in this
-    function. It is also covered in [2]_ as the kernel-smoothing choice probability
-    simulator.
+    The temperature parameter ``tau`` controls the smoothness of the function. For
+    ``tau`` close to 1, the function is more similar to ``max(x)`` and the derivatives
+    of the functions grow to infinity. As ``tau`` grows, the smoothed maximum is bigger
+    than the actual maximum and derivatives diminish. See [1]_ for more information on
+    the smoothing factor ``tau``. Note that the post covers the inverse of the smoothing
+    factor in this function. It is also covered in [2]_ as the kernel-smoothing choice
+    probability simulator. In reinforcement learning and statistical mechanics the
+    function is known as the Boltzmann exploration.
 
     .. [1] https://www.johndcook.com/blog/2010/01/13/soft-maximum
     .. [2] McFadden, D. (1989). A method of simulated moments for estimation of discrete
@@ -367,7 +368,7 @@ def log_softmax_i(x, i, k=1):
         be computed.
     i : int
         Index for which the log probability should be computed.
-    k : float
+    tau : float
         Smoothing parameter to control the size of derivatives.
 
     Returns
@@ -377,7 +378,7 @@ def log_softmax_i(x, i, k=1):
 
     """
     max_x = np.max(x)
-    smoothed_differences = (x - max_x) / k
+    smoothed_differences = (x - max_x) / tau
     log_sum_exp = np.log(np.sum(np.exp(smoothed_differences)))
     log_probability = smoothed_differences[i] - log_sum_exp
 

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -360,12 +360,28 @@ def log_softmax_i(x, i, k=1):
            response models without numerical integration. Econometrica: Journal of the
            Econometric Society, 995-1026.
 
+    Parameters
+    ----------
+    x : np.ndarray
+        Array with shape (n,) containing the values for which a smoothed maximum should
+        be computed.
+    i : int
+        Index for which the log probability should be computed.
+    k : float
+        Smoothing parameter to control the size of derivatives.
+
+    Returns
+    -------
+    log_probability : float
+        Log probability for input value ``i``.
+
     """
     max_x = np.max(x)
     smoothed_differences = (x - max_x) / k
     log_sum_exp = np.log(np.sum(np.exp(smoothed_differences)))
+    log_probability = smoothed_differences[i] - log_sum_exp
 
-    return smoothed_differences[i] - log_sum_exp
+    return log_probability
 
 
 @nb.guvectorize(


### PR DESCRIPTION
* respy version used, if any: 2.0.0dev
* Python version, if any: any
* Operating System: any

Closes #241.

### Current Behavior

The current calculation is prone to over- and underflows.

### Desired Bahavior

Make the function more robust.

### Solution / Implementation

- Extracted the log softmax function for readibility.
- The runtime increased from 0.2s to 2.7s for simulated data of 1,000 agents in ``kw_94_one``. I argue that this is negligible as currently the model is fitted on few observations and the real problem occurs in the solution.

### Todo

- [x] The computed value functions are not allowed to be infinity. We should make a new config variable ``MAX_FLOAT`` which is ``1e300`` and the max value of float64 is approx ``1e308``. This has to be rolled out to other functions as well, but only after robustness checks. POSTPONED
