### PR TITLE
Replace robust log likelihood aggregation with logsumexp.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,15 @@ extensions = [
 
 nitpicky = True
 
-autodoc_mock_imports = ["estimagic", "numba", "numpy", "pandas", "pytest", "yaml"]
+autodoc_mock_imports = [
+    "estimagic",
+    "numba",
+    "numpy",
+    "pandas",
+    "pytest",
+    "scipy",
+    "yaml",
+]
 
 intersphinx_mapping = {
     "numpy": ("https://docs.scipy.org/doc/numpy", None),

--- a/docs/development/randomness-and-reproducibility.rst
+++ b/docs/development/randomness-and-reproducibility.rst
@@ -104,7 +104,7 @@ in the sequence initialized by ``options["simulation_seed"]``.
 .. currentmodule:: respy.tests.random_model
 
 .. autosummary::
-    :toctree: ../generated/
+    :toctree: ../_generated/
 
     simulate_truncated_data
 

--- a/respy/likelihood.py
+++ b/respy/likelihood.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import numpy as np
 from numba import guvectorize
+from scipy.special import logsumexp
 
 from respy.conditional_draws import create_draws_and_log_prob_wages
 from respy.config import HUGE_FLOAT
@@ -308,15 +309,7 @@ def _internal_log_like_obs(
         log_type_probabilities = np.log(type_probabilities)
         weighted_loglikes = per_individual_loglikes + log_type_probabilities
 
-        # The following is equivalent to:
-        # writing contribs = np.log(np.exp(weighted_loglikes).sum(axis=1))
-        # but avoids overflows and underflows
-        minimal_m = -700 - weighted_loglikes.min(axis=1)
-        maximal_m = 700 - weighted_loglikes.max(axis=1)
-        valid = minimal_m <= maximal_m
-        m = np.where(valid, (minimal_m + maximal_m) / 2, np.nan).reshape(-1, 1)
-        contribs = np.log(np.exp(weighted_loglikes + m).sum(axis=1)) - m.flatten()
-        contribs[~valid] = -HUGE_FLOAT
+        contribs = logsumexp(weighted_loglikes, axis=1)
     else:
         contribs = per_individual_loglikes.flatten()
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,9 +57,8 @@ commands =
     - sphinx-build -WT -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/linkcheck
 
 [doc8]
-
-max-line-length=89
-ignore=D002,D004
+max-line-length = 89
+ignore = D002,D004
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
* respy version used, if any: any
* Python version, if any: any
* Operating System: any

### Current Behavior

Janos reinvented the wheel by showing us how to do robust log likelihood aggregation.

### Solution / Implementation

Unknown to us, the same concept already exists under the name logsumexp. The difference is that the ``m`` in Janos' case is the mid point of the largest and smallest value. Actually, one can simply use the max and thus prevent overflows all together. Underflows are more frequent with this method, but also underflows have less impact on the results, so we can neglect them in favor of bigger numbers.
