### PR TITLE
Add page on projects to documentation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,7 @@ releases are available on `Anaconda.org
   :ghuser:`tobiasraabe`).
 - :gh:`316` changes the invalid index value for the indexer to prevent silent errors
   (:ghuser:`tobiasraabe`).
+- :gh:`319` adds a page for projects using ``respy`` (:ghuser:`tobiasraabe`).
 
 
 1.2.1 - 2019-05-19

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,12 +18,13 @@ baseline model presented in:
 .. image:: https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     getting_started/index
     economics/index
     replications/index
     software/index
     development/index
+    projects
     api
     additional_information/index

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -1,0 +1,58 @@
+Projects
+========
+
+``respy`` is actively used as a research tool. Here is a list of projects to showcase
+the capabilities and kind of questions which are tackled with ``respy``.
+
+If you want to feature your project in this list, open an `issue or pr
+<https://github.com/OpenSourceEconomics/respy>`_ and submit a title, a summary, links to
+further resources, and contact details.
+
+Research
+--------
+
+Eisenhauer, P. (2019). `The Approximate Solution of Finite-Horizon Discrete Choice
+Dynamic Programming Models: Revisiting Keane & Wolpin (1994)
+<https://doi.org/10.1002/jae.2648>`_. *Journal of Applied Econometrics, 34* (1),
+149-154.
+
+    The estimation of finite‐horizon discrete‐choice dynamic programming (DCDP) models
+    is computationally expensive. This limits their realism and impedes verification and
+    validation efforts. `Keane and Wolpin (Review of Economics and Statistics, 1994,
+    76(4), 648–672) <https://doi.org/10.2307/2109768>`_ propose an interpolation method
+    that ameliorates the computational burden but introduces approximation error. I
+    describe their approach in detail, successfully recompute their original quality
+    diagnostics, and provide some additional insights that underscore the trade‐off
+    between computation time and the accuracy of estimation results.
+
+Contact: `@peisenha <https://github.com/peisenha>`_
+
+
+Thesis
+------
+
+Massner, P. (2019). Modeling Wage Uncertainty in Dynamic Life-cycle Models.
+
+    The thesis sheds light on the validity of the modeling assumptions of wage
+    uncertainty in dynamic life-cycle models of human capital investment. Since the
+    pioneering work of Keane and Wolpin (1997), a majority of studies in this field
+    followed the approach of assuming serially independent productivity shocks to wages.
+    In the case of Keane and Wolpin (1997), the independence assumption indeed
+    simplifies the numerical solution of the model compared to more complex
+    specifications, such as serial correlation. However, the assumption of i.i.d.
+    productivity shocks seems to be quite narrow in light of findings of the
+    reduced-form literature stream on wage dynamics.
+
+Contact: `@PatriziaMassner <https://github.com/PatriziaMassner>`_
+
+----
+
+Raabe, T. (2019). A unified estimation framework for some discrete choice dynamic
+programming models.
+
+    The thesis lays the foundation for ``respy`` to become a general framework for the
+    estimation of discrete choice dynamic programming models in labor economics. It
+    showcases the ability to represent Keane and Wolpin (1994), Keane and Wolpin (1997),
+    and Keane and Wolpin (2000) within a single implementation.
+
+Contact: `@tobiasraabe <https://github.com/tobiasraabe>`_


### PR DESCRIPTION
### Desired behavior

We want to have a page on finished and ongoing projects directly using respy or providing additional insights related to structural modeling and labor economics.