### PR TITLE
Add informative message if simulated individuals cannot be mapped to states.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.1
+    rev: v1.26.2
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/python/black
@@ -21,7 +21,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.3.0
+    rev: v1.5.0-1
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ releases are available on `Anaconda.org
   covariates.
 - :gh:`221` implements a new interface for the simulation which is similar to the
   estimation and reduces runtime for multiple simulations by a factor of four.
+- :gh:`230` allows the model to include observed variables which are time-invariant
+  (:ghuser:`mo2561057`, :ghuser:`tobiasraabe`)
 - :gh:`236` implements a periodic indexer.
 - :gh:`240` makes previous choices in the state space optional.
 - :gh:`245` create continuation values dynamically from value functions.
@@ -47,7 +49,7 @@ releases are available on `Anaconda.org
   and logsumexp, which reduce the likelihood of under- and overflows and save
   information (:ghuser:`tobiasraabe`).
 - :gh:`282` adds an interface for the estimation of models with the method of simulated
-  moments (:ghuser:`amageh`, :ghuser:`momo2561057`, :ghuser:`tobiasraabe`).
+  moments (:ghuser:`amageh`, :ghuser:`mo2561057`, :ghuser:`tobiasraabe`).
 - :gh:`285` adds the ability to generate a set of constraint for example models.
 - :gh:`288` fixes an error in the simulation of choice probabilities introduced by
   :gh:`278` (:ghuser:`peisenha`).
@@ -63,7 +65,8 @@ releases are available on `Anaconda.org
   (:ghuser:`tobiasraabe`).
 - :gh:`319` adds a page for projects using ``respy`` (:ghuser:`tobiasraabe`). :gh:`321`
   adds more projects.
-
+- :gh:`323` adds an informative message if simulated individuals cannot be mapped to
+  states in the state space (:ghuser:`mo2561057`, :ghuser:`tobiasraabe`).
 
 1.2.1 - 2019-05-19
 ------------------

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - nbsphinx=0.4.2
   - numba
   - numpydoc
-  - pandas>=0.24
+  - pandas>=0.24,<1
   - pdbpp
   - pyyaml
   - pytest

--- a/meta.yaml
+++ b/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - mkl
     - numba>=0.42
     - numpy
-    - pandas>=0.24
+    - pandas>=0.24,<1
     - pyyaml
     - pytest
     - scipy

--- a/respy/pre_processing/model_processing.py
+++ b/respy/pre_processing/model_processing.py
@@ -15,6 +15,7 @@ from estimagic.optimization.utilities import sdcorr_params_to_matrix
 
 from respy.config import DEFAULT_OPTIONS
 from respy.config import MAX_FLOAT
+from respy.config import MIN_FLOAT
 from respy.config import SEED_STARTUP_ITERATION_GAP
 from respy.pre_processing.model_checking import validate_options
 from respy.shared import normalize_probabilities
@@ -29,14 +30,14 @@ def process_params_and_options(params, options):
 
     """
     options = _read_options(options)
+    params = _read_params(params)
+
     options = {**DEFAULT_OPTIONS, **options}
     options = _create_internal_seeds_from_user_seeds(options)
     options = _identify_relevant_covariates(options, params)
     validate_options(options)
 
-    params = _read_params(params)
     optim_paras = _parse_parameters(params, options)
-
     optim_paras, options = _sync_optim_paras_and_options(optim_paras, options)
 
     return optim_paras, options
@@ -522,7 +523,7 @@ def _parse_lagged_choices(optim_paras, options, params):
         # If there are parameters, put zero probability on missing choices.
         else:
             defaults = {
-                choice: pd.Series(index=["constant"], data=-MAX_FLOAT)
+                choice: pd.Series(index=["constant"], data=MIN_FLOAT)
                 for choice in optim_paras["choices"]
             }
             parsed_parameters = {**defaults, **parsed_parameters}

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ conda_deps =
     mkl
     numba
     numpy
-    pandas >= 0.24
+    pandas >= 0.24, <1
     scipy
     pyaml
     pytest


### PR DESCRIPTION
### Current behavior

#316 added a new indexer which will cause IndexError if simulated individuals cannot be sampled.

If there is a mismatch between core state space filters and the initial conditions, an IndexError might be raised, but is completely uninformative about the nature of the cause.

This happened in #322.

### Solution

- Add better error message to indexerror.
- Excluse pandas version 1 for now.