### PR TITLE
Improve how we calculate coverage

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -7,6 +7,9 @@ on:
     branches:
     - '*'
 
+env:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 jobs:
   run-tests:
     name: Run tests for ${{ matrix.os }} on ${{ matrix.python-version }}
@@ -51,13 +54,13 @@ jobs:
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F unit_precise -c
 
-      - name: Run unit tests which are edge cases.
-        shell: bash -l {0}
-        run: tox -e pytest -- -m "not slow and unit and edge_case" --cov=./ --cov-report=xml
+      # - name: Run unit tests which are edge cases.
+      #   shell: bash -l {0}
+      #   run: tox -e pytest -- -m "not slow and unit and edge_case" --cov=./ --cov-report=xml
 
-      - name: Upload coverage report
-        shell: bash -l {0}
-        run: bash <(curl -s https://codecov.io/bash) -F unit_edge_case -c
+      # - name: Upload coverage report
+      #   shell: bash -l {0}
+      #   run: bash <(curl -s https://codecov.io/bash) -F unit_edge_case -c
 
       - name: Run unit tests which neither precise nor an edge case.
         shell: bash -l {0}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,6 +51,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and unit and precise or (not integration and not end_to_end)" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F unit_precise -c
 
@@ -59,6 +60,7 @@ jobs:
       #   run: tox -e pytest -- -m "not slow and unit and edge_case" --cov=./ --cov-report=xml
 
       # - name: Upload coverage report
+      #   if: runner.os == 'Linux' && matrix.python-version == '3.7'
       #   shell: bash -l {0}
       #   run: bash <(curl -s https://codecov.io/bash) -F unit_edge_case -c
 
@@ -67,6 +69,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and unit and not precise and not edge_case" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F unit_rest -c
 
@@ -77,6 +80,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and integration and precise" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F integration_precise -c
 
@@ -85,6 +89,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and integration and edge_case" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F integration_edge_case -c
 
@@ -93,6 +98,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and integration and not precise and not edge_case" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F integration_rest -c
 
@@ -103,6 +109,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and end_to_end and precise" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F end_to_end_precise -c
 
@@ -111,6 +118,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and end_to_end and edge_case" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F end_to_end_edge_case -c
 
@@ -119,6 +127,7 @@ jobs:
         run: tox -e pytest -- -m "not slow and end_to_end and not precise and not edge_case" --cov=./ --cov-report=xml
 
       - name: Upload coverage report
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash) -F end_to_end_rest -c
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -32,20 +32,94 @@ jobs:
         shell: bash -l {0}
         run: conda install -c conda-forge -c opensourceeconomics conda-build estimagic matplotlib
 
-      - name: Run pytest.
-        shell: bash -l {0}
-        run: tox -e pytest -- -m "not slow" --cov-report=xml --cov=./
-
       - name: Validate codecov.yml
         if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: cat codecov.yml | curl --data-binary @- https://codecov.io/validate
 
-      - name: Upload coverage report.
-        if: runner.os == 'Linux' && matrix.python-version == '3.7'
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      ###############
+      # Test Matrix #
+      ###############
+
+      # Unit tests.
+
+      - name: Run precise unit tests and doctests.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and unit and precise or (not integration and not end_to_end)" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F unit_precise -c
+
+      - name: Run unit tests which are edge cases.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and unit and edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F unit_edge_case -c
+
+      - name: Run unit tests which neither precise nor an edge case.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and unit and not precise and not edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F unit_rest -c
+
+      # Integration tests.
+
+      - name: Run precise integration tests.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and integration and precise" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F integration_precise -c
+
+      - name: Run integration tests which are edge cases.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and integration and edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F integration_edge_case -c
+
+      - name: Run integration tests which neither precise nor an edge case.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and integration and not precise and not edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F integration_rest -c
+
+      # End-to-end tests.
+
+      - name: Run precise end_to_end tests.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and end_to_end and precise" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F end_to_end_precise -c
+
+      - name: Run end_to_end tests which are edge cases.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and end_to_end and edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F end_to_end_edge_case -c
+
+      - name: Run end_to_end tests which neither precise nor an edge case.
+        shell: bash -l {0}
+        run: tox -e pytest -- -m "not slow and end_to_end and not precise and not edge_case" --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash) -F end_to_end_rest -c
+
+      # Run other tests.
 
       - name: Run sphinx.
         if: runner.os == 'Linux' && matrix.python-version == '3.7'

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,35 @@ coverage:
       default:
         threshold: 5%
 
+flags:
+  unit_precise:
+    paths:
+      - .
+  unit_edge_case:
+    paths:
+      - .
+  unit_rest:
+    paths:
+      - .
+  integration_precise:
+    paths:
+      - .
+  integration_edge_case:
+    paths:
+      - .
+  integration_rest:
+    paths:
+      - .
+  end_to_end_precise:
+    paths:
+      - .
+  end_to_end_edge_case:
+    paths:
+      - .
+  end_to_end_rest:
+    paths:
+      - .
+
 ignore:
   - ".tox/**/*"
   - "release.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,43 +1,41 @@
 coverage:
-  range: 50...100
   precision: 2
   round: down
+  range: 80...100
   status:
     project:
       default:
-        threshold: 5%
-    patch:
-      default:
-        threshold: 5%
-
-flags:
-  unit_precise:
-    paths:
-      - .
-  unit_edge_case:
-    paths:
-      - .
-  unit_rest:
-    paths:
-      - .
-  integration_precise:
-    paths:
-      - .
-  integration_edge_case:
-    paths:
-      - .
-  integration_rest:
-    paths:
-      - .
-  end_to_end_precise:
-    paths:
-      - .
-  end_to_end_edge_case:
-    paths:
-      - .
-  end_to_end_rest:
-    paths:
-      - .
+        threshold: 1%
+      patch:
+        default:
+          threshold: 5%
+      unit_precise:
+        flags:
+          - unit_precise
+      # unit_edge_case:
+      #   flags:
+      #     - unit_edge_case
+      unit_rest:
+        flags:
+          - unit_rest
+      integration_precise:
+        flags:
+          - integration_precise
+      integration_edge_case:
+        flags:
+          - integration_edge_case
+      integration_rest:
+        flags:
+          - integration_rest
+      end_to_end_precise:
+        flags:
+          - end_to_end_precise
+      end_to_end_edge_case:
+        flags:
+          - end_to_end_edge_case
+      end_to_end_rest:
+        flags:
+          - end_to_end_rest
 
 ignore:
   - ".tox/**/*"

--- a/respy/conftest.py
+++ b/respy/conftest.py
@@ -88,16 +88,3 @@ def pytest_generate_tests(metafunc):
         # Else, parametrize with the seeds.
         else:
             metafunc.parametrize(argument, seeds)
-
-
-def pytest_configure(config):
-    """Register custom markers."""
-    markers = [
-        "precise: Tests that assert a numeric value is correct, up to rounding error.",
-        "edge_case: Tests that exploit edge cases with closed form solutions",
-        "unit: Unit tests, i.e. tests that only test one function in isolation.",
-        "integration: Tests that test the interplay of several functions.",
-        "end_to_end: Tests that test the whole system.",
-    ]
-    for marker in markers:
-        config.addinivalue_line("markers", marker)

--- a/respy/conftest.py
+++ b/respy/conftest.py
@@ -88,3 +88,16 @@ def pytest_generate_tests(metafunc):
         # Else, parametrize with the seeds.
         else:
             metafunc.parametrize(argument, seeds)
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    markers = [
+        "precise: Tests that assert a numeric value is correct, up to rounding error.",
+        "edge_case: Tests that exploit edge cases with closed form solutions",
+        "unit: Unit tests, i.e. tests that only test one function in isolation.",
+        "integration: Tests that test the interplay of several functions.",
+        "end_to_end: Tests that test the whole system.",
+    ]
+    for marker in markers:
+        config.addinivalue_line("markers", marker)

--- a/respy/tests/test_conditional_draws.py
+++ b/respy/tests/test_conditional_draws.py
@@ -20,6 +20,8 @@ def kalman_results():
     return fix
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 @pytest.mark.parametrize("i", range(20))
 def test_update_and_evaluate_likelihood(i, kalman_results):
     inp = kalman_results["mean"][i]["input"]
@@ -30,6 +32,8 @@ def test_update_and_evaluate_likelihood(i, kalman_results):
     aaae(calculated_like, expected_like)
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 @pytest.mark.parametrize("i", range(10))
 def test_update_cholcovs_with_error(i, kalman_results):
     inp = kalman_results["cov_error"][i]["input"]
@@ -44,6 +48,8 @@ def test_update_cholcovs_with_error(i, kalman_results):
     aaae(calculated_cov, expected_cov)
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 def test_update_cholcovs():
     cov = np.array([[1, 0.8, 0.8], [0.8, 1, 0.8], [0.8, 0.8, 1]])
 
@@ -62,6 +68,8 @@ def test_update_cholcovs():
     aaae(calculated[i], expected[i], decimal=5)
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 def test_calculate_conditional_draws():
     draws = np.array([[0.5, -1, 1]])
     updated_mean = np.arange(3)

--- a/respy/tests/test_integration.py
+++ b/respy/tests/test_integration.py
@@ -1,9 +1,12 @@
+import pytest
+
 from respy.likelihood import get_crit_func
 from respy.tests.random_model import add_noise_to_params
 from respy.tests.random_model import generate_random_model
 from respy.tests.random_model import simulate_truncated_data
 
 
+@pytest.mark.end_to_end
 def test_simulation_and_estimation_with_different_models():
     """Test the evaluation of the criterion function not at the true parameters."""
     # Simulate a dataset
@@ -19,6 +22,7 @@ def test_simulation_and_estimation_with_different_models():
     crit_func(params)
 
 
+@pytest.mark.end_to_end
 def test_invariant_results_for_two_estimations():
     params, options = generate_random_model()
     df = simulate_truncated_data(params, options)

--- a/respy/tests/test_interface.py
+++ b/respy/tests/test_interface.py
@@ -5,11 +5,13 @@ from respy.interface import get_example_model
 from respy.interface import get_parameter_constraints
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("model", EXAMPLE_MODELS)
 def test_get_example_model(model):
     params, options = get_example_model(model, with_data=False)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("model", EXAMPLE_MODELS)
 def test_get_parameter_constraints(model):
     get_parameter_constraints(model)

--- a/respy/tests/test_interpolate.py
+++ b/respy/tests/test_interpolate.py
@@ -1,7 +1,10 @@
+import pytest
+
 from respy.solve import get_solve_func
 from respy.tests.utils import process_model_or_seed
 
 
+@pytest.mark.end_to_end
 def test_run_through_of_solve_with_interpolation(seed):
     params, options = process_model_or_seed(
         seed, point_constr={"n_periods": 5, "interpolation_points": 10}

--- a/respy/tests/test_likelihood.py
+++ b/respy/tests/test_likelihood.py
@@ -7,6 +7,7 @@ from respy.simulate import get_simulate_func
 from respy.tests.utils import process_model_or_seed
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("model", ["kw_94_one", "kw_97_basic"])
 def test_return_comparison_plot_data_for_likelihood(model):
     params, options = process_model_or_seed(model)
@@ -26,6 +27,7 @@ def test_return_comparison_plot_data_for_likelihood(model):
     assert isinstance(df, pd.DataFrame)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("model", ["kw_94_one", "kw_97_basic"])
 def test_return_scalar_for_likelihood(model):
     params, options = process_model_or_seed(model)

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -34,6 +34,8 @@ def inputs():
     )
 
 
+@pytest.mark.edgecase
+@pytest.mark.end_to_end
 def test_msm_zero(inputs):
     """ Test whether msm function successfully returns 0 for true parameter
     vector.
@@ -45,6 +47,7 @@ def test_msm_zero(inputs):
     assert (msm_vector(inputs[0]) == 0).all()
 
 
+@pytest.mark.end_to_end
 def test_msm_nonzero(inputs):
     """ Test whether msm function successfully returns a value larger than 0
     for different deviations in the simulated set.
@@ -66,6 +69,8 @@ def test_msm_nonzero(inputs):
     assert msm_seed(inputs[0]) > 0
 
 
+@pytest.mark.edgecase
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("model_or_seed", ["kw_94_one", "kw_97_basic"])
 def test_randomness_msm(model_or_seed):
     params, options = process_model_or_seed(model_or_seed)

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -34,7 +34,7 @@ def inputs():
     )
 
 
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 @pytest.mark.end_to_end
 def test_msm_zero(inputs):
     """ Test whether msm function successfully returns 0 for true parameter
@@ -69,7 +69,7 @@ def test_msm_nonzero(inputs):
     assert msm_seed(inputs[0]) > 0
 
 
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 @pytest.mark.end_to_end
 @pytest.mark.parametrize("model_or_seed", ["kw_94_one", "kw_97_basic"])
 def test_randomness_msm(model_or_seed):

--- a/respy/tests/test_model_processing.py
+++ b/respy/tests/test_model_processing.py
@@ -33,6 +33,7 @@ def test_generate_random_model():
     assert isinstance(crit_val, float)
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("model_or_seed", EXAMPLE_MODELS)
 def test_model_options(model_or_seed):
     _, options = process_model_or_seed(model_or_seed)
@@ -42,6 +43,8 @@ def test_model_options(model_or_seed):
     validate_options(options)
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_parse_initial_and_max_experience():
     """Test ensures that probabilities are transformed with logs and rest passes."""
     choices = ["a", "b"]
@@ -79,6 +82,8 @@ def test_parse_initial_and_max_experience():
     assert optim_paras["choices"]["b"]["max"] == 5
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_normalize_probabilities():
     constraints = {"observables": [3]}
     params, options = generate_random_model(point_constr=constraints)
@@ -103,6 +108,8 @@ def test_normalize_probabilities():
         )
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_convert_labels_in_covariates_to_codes():
     optim_paras = {
         "choices": ["fishing", "hammock"],
@@ -131,6 +138,8 @@ def test_convert_labels_in_covariates_to_codes():
     assert options["covariates"] == expected
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_parse_observables():
     params = pd.read_csv(
         io.StringIO(
@@ -166,6 +175,8 @@ def test_parse_observables():
             )
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_raise_exception_for_missing_meas_error():
     params, options = generate_random_model()
 
@@ -175,6 +186,8 @@ def test_raise_exception_for_missing_meas_error():
         _parse_measurement_errors(params, options)
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_raise_exception_for_missing_shock_matrix():
     params, _ = generate_random_model()
 
@@ -184,6 +197,8 @@ def test_raise_exception_for_missing_shock_matrix():
         _parse_shocks({}, params)
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 @pytest.mark.parametrize("observables", [[2], [2, 2]])
 def test_raise_exception_for_observable_with_one_value(observables):
     point_constr = {"observables": observables}

--- a/respy/tests/test_process_covariates.py
+++ b/respy/tests/test_process_covariates.py
@@ -2,10 +2,13 @@ import io
 from textwrap import dedent
 
 import pandas as pd
+import pytest
 
 from respy.pre_processing.process_covariates import remove_irrelevant_covariates
 
 
+@pytest.mark.unit
+@pytest.mark.precise
 def test_identify_relevant_covariates():
     params = pd.read_csv(
         io.StringIO(

--- a/respy/tests/test_randomness.py
+++ b/respy/tests/test_randomness.py
@@ -9,6 +9,7 @@ from respy.tests.utils import apply_to_attributes_of_two_state_spaces
 from respy.tests.utils import process_model_or_seed
 
 
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("model", ["kw_94_one", "kw_97_basic", "kw_2000"])
 def test_invariance_of_model_solution_in_solve_and_criterion_functions(model):
     params, options = process_model_or_seed(model)

--- a/respy/tests/test_regression.py
+++ b/respy/tests/test_regression.py
@@ -32,6 +32,7 @@ def regression_vault():
     return load_regression_tests()
 
 
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("index", range(10))
 def test_single_regression(regression_vault, index):
     """Run a single regression test."""

--- a/respy/tests/test_replication_kw_94.py
+++ b/respy/tests/test_replication_kw_94.py
@@ -34,6 +34,8 @@ from respy.config import TEST_RESOURCES_DIR
 pytestmark = pytest.mark.slow
 
 
+@pytest.mark.end_to_end
+@pytest.mark.precise
 def test_table_6_exact_solution_row_mean_and_sd():
     """Replicate the first two rows of Table 6 in Keane and Wolpin (1994).
 
@@ -110,6 +112,8 @@ def test_table_6_exact_solution_row_mean_and_sd():
     assert (np.abs(diff) < kw_94_table_6.iloc[1]).all()
 
 
+@pytest.mark.end_to_end
+@pytest.mark.precise
 @pytest.mark.parametrize(
     "model, table",
     zip(

--- a/respy/tests/test_replication_kw_97.py
+++ b/respy/tests/test_replication_kw_97.py
@@ -8,6 +8,8 @@ import respy as rp
 pytestmark = pytest.mark.slow
 
 
+@pytest.mark.end_to_end
+@pytest.mark.precise
 @pytest.mark.parametrize(
     "model, type_proportions",
     [
@@ -51,6 +53,8 @@ def test_type_proportions(model, type_proportions):
     )
 
 
+@pytest.mark.end_to_end
+@pytest.mark.precise
 def test_distribution_of_lagged_choices():
     params, options, actual_df = rp.get_example_model("kw_97_extended")
 

--- a/respy/tests/test_simulate.py
+++ b/respy/tests/test_simulate.py
@@ -40,7 +40,7 @@ def test_one_step_ahead_simulation():
 
 
 @pytest.mark.end_to_end
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 def test_equality_for_myopic_agents_and_tiny_delta():
     """Test equality of simulated data and likelihood with myopia and tiny delta."""
     # Get simulated data and likelihood for myopic model.
@@ -70,7 +70,7 @@ def test_equality_for_myopic_agents_and_tiny_delta():
 
 
 @pytest.mark.end_to_end
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 def test_equality_of_models_with_and_without_observables():
     """Test equality of models with and without observables.
 

--- a/respy/tests/test_simulate.py
+++ b/respy/tests/test_simulate.py
@@ -13,6 +13,7 @@ from respy.tests.random_model import generate_random_model
 from respy.tests.utils import process_model_or_seed
 
 
+@pytest.mark.end_to_end
 @pytest.mark.parametrize("model_or_seed", EXAMPLE_MODELS)
 def test_simulated_data(model_or_seed):
     """Test simulated data with ``check_simulated_data``.
@@ -30,6 +31,7 @@ def test_simulated_data(model_or_seed):
     check_simulated_data(optim_paras, df)
 
 
+@pytest.mark.end_to_end
 def test_one_step_ahead_simulation():
     params, options, df = rp.get_example_model("kw_97_basic")
     options["n_periods"] = 11
@@ -37,6 +39,8 @@ def test_one_step_ahead_simulation():
     df = simulate(params)
 
 
+@pytest.mark.end_to_end
+@pytest.mark.edgecase
 def test_equality_for_myopic_agents_and_tiny_delta():
     """Test equality of simulated data and likelihood with myopia and tiny delta."""
     # Get simulated data and likelihood for myopic model.
@@ -65,6 +69,8 @@ def test_equality_for_myopic_agents_and_tiny_delta():
     np.testing.assert_almost_equal(likelihood, likelihood_, decimal=12)
 
 
+@pytest.mark.end_to_end
+@pytest.mark.edgecase
 def test_equality_of_models_with_and_without_observables():
     """Test equality of models with and without observables.
 
@@ -110,6 +116,8 @@ def test_equality_of_models_with_and_without_observables():
     pd.testing.assert_frame_equal(df_, df)
 
 
+@pytest.mark.end_to_end
+@pytest.mark.precise
 def test_distribution_of_observables():
     """Test that the distribution of observables matches the simulated distribution."""
     # Now specify a set of observables

--- a/respy/tests/test_solve.py
+++ b/respy/tests/test_solve.py
@@ -219,7 +219,7 @@ def test_create_state_space_vs_specialized_kw97(model):
         assert np.array_equal(mask_old, adj_mask_new)
 
 
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 @pytest.mark.integration
 def test_explicitly_nonpec_choice_rewards_of_kw_94_one():
     params, options = get_example_model("kw_94_one", with_data=False)
@@ -232,7 +232,7 @@ def test_explicitly_nonpec_choice_rewards_of_kw_94_one():
     assert (state_space.nonpecs[:, 3] == 17_750).all()
 
 
-@pytest.mark.edgecase
+@pytest.mark.edge_case
 @pytest.mark.integration
 def test_explicitly_nonpec_choice_rewards_of_kw_94_two():
     params, options = get_example_model("kw_94_two", with_data=False)

--- a/respy/tests/test_solve.py
+++ b/respy/tests/test_solve.py
@@ -32,6 +32,8 @@ def test_check_solution(model_or_seed):
     check_model_solution(optim_paras, options, state_space)
 
 
+@pytest.mark.integration
+@pytest.mark.precise
 @pytest.mark.parametrize("model", EXAMPLE_MODELS)
 def test_state_space_restrictions_by_traversing_forward(model):
     """Test for inadmissible states in the state space.
@@ -89,6 +91,7 @@ def test_state_space_restrictions_by_traversing_forward(model):
     assert set_valid_indices == set(range(state_space.core.shape[0]))
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("model_or_seed", EXAMPLE_MODELS)
 def test_invariance_of_solution(model_or_seed):
     """Test for the invariance of the solution.
@@ -129,6 +132,8 @@ def test_invariance_of_solution(model_or_seed):
     )
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 @pytest.mark.parametrize("model", KEANE_WOLPIN_1994_MODELS)
 def test_create_state_space_vs_specialized_kw94(model):
     point_constr = {"n_lagged_choices": 1, "observables": False}
@@ -166,6 +171,8 @@ def test_create_state_space_vs_specialized_kw94(model):
         assert np.array_equal(mask_old, mask_new)
 
 
+@pytest.mark.precise
+@pytest.mark.unit
 @pytest.mark.parametrize("model", KEANE_WOLPIN_1997_MODELS)
 def test_create_state_space_vs_specialized_kw97(model):
     params, options = process_model_or_seed(model)
@@ -212,6 +219,8 @@ def test_create_state_space_vs_specialized_kw97(model):
         assert np.array_equal(mask_old, adj_mask_new)
 
 
+@pytest.mark.edgecase
+@pytest.mark.integration
 def test_explicitly_nonpec_choice_rewards_of_kw_94_one():
     params, options = get_example_model("kw_94_one", with_data=False)
 
@@ -223,6 +232,8 @@ def test_explicitly_nonpec_choice_rewards_of_kw_94_one():
     assert (state_space.nonpecs[:, 3] == 17_750).all()
 
 
+@pytest.mark.edgecase
+@pytest.mark.integration
 def test_explicitly_nonpec_choice_rewards_of_kw_94_two():
     params, options = get_example_model("kw_94_two", with_data=False)
 

--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,11 @@ addopts = --doctest-modules
 markers =
     slow: Tests that take a long time to run.
     wip: Tests that are work-in-progress.
+    precise: Tests that assert a numeric value is correct, up to rounding error.
+    edge_case: Tests that exploit edge cases with closed form solutions,
+    unit: Unit tests, i.e. tests that only test one function in isolation.
+    integration: Tests that test the interplay of several functions.
+    end_to_end: Tests that test the whole system.
 warn-symbols =
     pytest.mark.wip = Remove 'wip' flag for tests.
     pytest.mark.skip = Remove 'skip' flag for tests.


### PR DESCRIPTION
### Current behavior

We have one coverage report that treats all tests equally. 

### Desired behavior

Different types of tests should have different coverage reports. In particular we want to distinguish tests along two dimensions:
1. How local the test is: Unit tests just test one function, integration tests look at the interplay of several functions and end_to_end tests run the whole system
2. How strict the test is: Some tests compare the full output of a function with a independently calculated result (we call them "precise" tests). Others exploit an edgecase, i.e. also make a precise assert statement but only on a very extreme branch of the code. Some tests only make sure that the code runs without raising errors.

### Solution / Implementation

We use markers for all of the above mentioned cases and create separate coverage reports for all possible combinations of markers. Note that within one dimension, markers are mutually exclusive, such that we and up with 9 coverage reports. 

### Todo

- [ ] Generate the reports. 