### PR TITLE
Example model sd timmens

### DIFF
--- a/respy/interface.py
+++ b/respy/interface.py
@@ -46,7 +46,7 @@ ROBINSON_CRUSOE_CONSTRAINTS = [
 ]
 
 
-def get_example_model(model, with_data=True):
+def get_example_model(model, with_data=True, with_sd=False):
     """Return parameters, options and data (optional) of an example model.
 
     Parameters
@@ -58,6 +58,9 @@ def get_example_model(model, with_data=True):
     with_data : bool
         Whether the accompanying data set should be returned. For some data sets, real
         data can be provided, for others, a simulated data set will be produced.
+    with_sd : bool
+        Wether the returned params data frame should contain standard deviations of
+        estimated parameters or only means.
 
     """
     assert model in EXAMPLE_MODELS, f"{model} is not in {EXAMPLE_MODELS}."
@@ -66,6 +69,17 @@ def get_example_model(model, with_data=True):
     params = pd.read_csv(
         TEST_RESOURCES_DIR / f"{model}.csv", index_col=["category", "name"]
     )
+
+    if with_sd is True:
+        if model != "kw_97_basic":
+            warnings.warn(
+                f"No standard deviation available for model '{model}'.",
+                category=UserWarning,
+            )
+        params_sd = pd.read_csv(
+            TEST_RESOURCES_DIR / f"{model}_sd.csv", index_col=["category", "name"]
+        )
+        params = pd.concat([params, params_sd], keys=["mean", "sd"], names="type")
 
     if "kw_97" in model and with_data:
         df = (create_kw_97(params, options),)

--- a/respy/tests/resources/kw_97_basic_sd.csv
+++ b/respy/tests/resources/kw_97_basic_sd.csv
@@ -1,0 +1,52 @@
+category,name,value,comment
+delta,delta,0.0048,discount factor
+wage_white_collar,constant,0.0124,log of rental price if the base skill endowment of type 0 is normalized to 0 (wage)
+wage_white_collar,exp_school,0.0014,linear return to an additional year of schooling (wage)
+wage_white_collar,exp_white_collar,0.0015,"return to experience, same sector, linear (wage)"
+wage_white_collar,exp_white_collar_square,0.0032,"return to experience, same sector, quadratic (divided by 100) (wage)"
+wage_white_collar,exp_blue_collar,0.0017,"return to experience, other civilian sector, linear (wage)"
+wage_white_collar,exp_military,0.0007,"return to experience, military sector, linear (wage)"
+wage_white_collar,type_1,0.0047,deviation for type 1 from type 0 in a
+wage_white_collar,type_2,0.01,deviation for type 2 from type 0 in a
+wage_white_collar,type_3,0.0176,deviation for type 3 from type 0 in a
+wage_blue_collar,constant,0.0126,log of rental price if the base skill endowment of type 0 is normalized to 0 (wage)
+wage_blue_collar,exp_school,0.0014,linear return to an additional year of schooling (wage)
+wage_blue_collar,exp_white_collar,0.0674,"return to experience, other civilian sector, linear (wage)"
+wage_blue_collar,exp_blue_collar,0.0011,"return to experience, same sector, linear (wage)"
+wage_blue_collar,exp_blue_collar_square,0.0041,"return to experience, same sector, quadratic (divided by 100) (wage)"
+wage_blue_collar,exp_military,0.0021,"return to experience, military sector, linear (wage)"
+wage_blue_collar,type_1,0.0094,deviation for type 1 from type 0 in b
+wage_blue_collar,type_2,0.0079,deviation for type 2 from type 0 in b
+wage_blue_collar,type_3,0.0058,deviation for type 3 from type 0 in b
+wage_military,constant,0.0234,log of rental price if the base skill endowment of type 0 is normalized to 0 (wage)
+wage_military,exp_school,0.0027,linear return to an additional year of schooling (wage)
+wage_military,exp_military,0.0122,"return to experience, same sector, linear (wage)"
+wage_military,exp_military_square,0.2156,"return to experience, same sector, quadratic (divided by 100) (wage)"
+nonpec_school,constant,850.0,consumption value of school attendance for type 0
+nonpec_school,hs_graduate,156.0,consumption value of college
+nonpec_school,co_graduate,737.0,consumption value of graduate school
+nonpec_school,type_1,757.0,deviation for type 1 from type 0 in edu
+nonpec_school,type_2,754.0,deviation for type 2 from type 0 in edu
+nonpec_school,type_3,594.0,deviation for type 3 from type 0 in edu
+nonpec_home,constant,413.0,mean value of non-market alternative for type 0
+nonpec_home,type_1,377.0,deviation for type 1 from type 0 in home
+nonpec_home,type_2,542.0,deviation for type 2 from type 0 in home
+nonpec_home,type_3,1000.0,deviation for type 3 from type 0 in home
+shocks_sdcorr,sd_blue_collar,0.007,standard deviation of the shock in occupation b
+shocks_sdcorr,sd_military,0.0156,standard deviation of the shock in occupation military
+shocks_sdcorr,sd_white_collar,0.0077,standard deviation of the shock in occupation a
+shocks_sdcorr,sd_school,105.0,standard deviation of the shock in the education sector
+shocks_sdcorr,sd_home,460.0,standard deviation of the shock in the home sector
+shocks_sdcorr,corr_military_blue_collar,0.0505,correlation between the shocks in military and b
+shocks_sdcorr,corr_white_collar_blue_collar,0.0252,correlation between the shocks in occupation a and b
+shocks_sdcorr,corr_white_collar_military,0.0245,correlation between the shocks in military and a
+shocks_sdcorr,corr_school_blue_collar,0.0,correlation between the shocks in the education sector and b
+shocks_sdcorr,corr_school_military,0.0,correlation between the shocks in the education sector and military
+shocks_sdcorr,corr_school_white_collar,0.0,correlation between the shocks in the education sector and a
+shocks_sdcorr,corr_home_blue_collar,0.0,correlation between the shocks in home sector and b
+shocks_sdcorr,corr_home_military,0.0,correlation between the shocks in home sector and military
+shocks_sdcorr,corr_home_white_collar,0.0,correlation between the shocks in home sector and a
+shocks_sdcorr,corr_home_school,0.0,correlation between the shocks in home sector and education
+meas_error,sd_blue_collar,0.0055,SD of the measurement error in wages occupation b
+meas_error,sd_military,0.0166,SD of the measurement error in wages occupation mil
+meas_error,sd_white_collar,0.0065,SD of the measurement error in wages in occupation a

--- a/respy/visualize.py
+++ b/respy/visualize.py
@@ -1,0 +1,1 @@
+"""Everything related to visualizing simulation results."""


### PR DESCRIPTION
### Current behavior

Currently when asking for the params of an example model via ``rp.get_example_model``, for example with ``model="kw_97_basis"``, only the mean estimates of the model are returned and not the estimated standard deviations.

### Desired behavior

An option which enables the return of the standard deviations in a bigger params data frame which has a third level on the multiindex for "mean", the classical params data frame, and "sd" the values for the standard deviations.

### Solution / Implementation

See above.

### Todo

- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in CHANGES.rst.
