### PR TITLE
Add comparison_plot_data to msm and return moments.

### DIFF
--- a/docs/how_to_guides/msm.ipynb
+++ b/docs/how_to_guides/msm.ipynb
@@ -46,7 +46,7 @@
     "* weighting_matrix (numpy.ndarray)\n",
     "* n_simulation_periods (int, default None)\n",
     "* return_scalar (bool, default True)\n",
-    "* return_moments (bool, default False)\n",
+    "* return_simulated_moments (bool, default False)\n",
     "* return_comparison_plot_data (bool, default False)\n",
     "\n",
     "\n",
@@ -1115,9 +1115,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### The *return_moments* Argument\n",
+    "#### The *return_simulated_moments* Argument\n",
     "\n",
-    "If *return_moments* is set to **True**, the msm function will return the simulated and empircal moments in addition to the function value or moment error vectors. This can be useful for visualization purposes and to compare moments directly for a given parameterization. Its default value is **False**."
+    "If *return_simulated_moments* is set to **True**, the msm function will return the simulated in addition to the function value or moment error vector. This can be useful for visualization purposes and to compare simulated moments to empirical moments for a given parameterization. Its default value is **False**."
    ]
   },
   {
@@ -1126,7 +1126,7 @@
    "source": [
     "#### The *return_comparison_plot_data* Argument\n",
     "\n",
-    "Similarily to *return_moments*, the *return_comparison_plot_data* argument can be used to return the empirical and simulated moments with other function output. Instead of lists, the data will be saved to one pandas.DataFrame that is designed to compliment the visualization capabilities of [estimagic](https://github.com/OpenSourceEconomics/estimagic). It is **False** by default and acts as a substitute for *return_moments*, meaning only one can be set to **True** at the same time."
+    "Similarly to *return_simulated_moments*, the *return_comparison_plot_data* argument can be used to return the empirical and simulated moments with other function output. Instead of lists, the data will be saved to one pandas.DataFrame that is designed to compliment the visualization capabilities of [estimagic](https://github.com/OpenSourceEconomics/estimagic). It is **False** by default and acts as a substitute for *return_simulated_moments*, meaning only one can be set to **True** at the same time."
    ]
   },
   {

--- a/docs/how_to_guides/msm.ipynb
+++ b/docs/how_to_guides/msm.ipynb
@@ -46,6 +46,8 @@
     "* weighting_matrix (numpy.ndarray)\n",
     "* n_simulation_periods (int, default None)\n",
     "* return_scalar (bool, default True)\n",
+    "* return_moments (bool, default False)\n",
+    "* return_comparison_plot_data (bool, default False)\n",
     "\n",
     "\n",
     "`get_msm_func` returns a function where all arguments except *params* are held fixed. The returned function can then easily be passed on to an optimizer for estimation."
@@ -1107,6 +1109,24 @@
     "#### The *return_scalar* Argument\n",
     "\n",
     "The *return_scalar* argument allows us to return the moment errors in vector form. `get_msm_func` will return the moment error vector if *return_scalar* is set to **False** and will return the value of the weighted square product of the moment errors if *return_scalar* is set to **True** which is also the default."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The *return_moments* Argument\n",
+    "\n",
+    "If *return_moments* is set to **True**, the msm function will return the simulated and empircal moments in addition to the function value or moment error vectors. This can be useful for visualization purposes and to compare moments directly for a given parameterization. Its default value is **False**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The *return_comparison_plot_data* Argument\n",
+    "\n",
+    "Similarily to *return_moments*, the *return_comparison_plot_data* argument can be used to return the empirical and simulated moments with other function output. Instead of lists, the data will be saved to one pandas.DataFrame that is designed to compliment the visualization capabilities of [estimagic](https://github.com/OpenSourceEconomics/estimagic). It is **False** by default and acts as a substitute for *return_moments*, meaning only one can be set to **True** at the same time."
    ]
   },
   {

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -85,7 +85,8 @@ releases are available on `Anaconda.org
   pre-defined models.
 - :gh:`361` adds standard deviations of parameters for example models
   (:ghuser:`timmens`).
-
+- :gh:`363` enables msm function to return simulated moments or comparison plot data for 
+  use with `estimagic <https://github.com/OpenSourceEconomics/estimagic>`_ (:ghuser:`amageh`).
 
 *Releases prior to the second version were published on PyPI, but later deleted. You can
 still checkout the following releases using the corresponding tags in the repository.*

--- a/respy/method_of_simulated_moments.py
+++ b/respy/method_of_simulated_moments.py
@@ -75,8 +75,18 @@ def get_msm_func(
         Indicates whether moments should be returned with other output. If True will
         return a tuple of empirical_moments and simulated moments in list form.
     return_comparison_plot_data: bool, default False
-        Indicator for whether a :class:`pandas.DataFrame` with various contributions
-        for the visualization with estimagic should be returned.
+        Indicator for whether a :class:`pandas.DataFrame` with empirical and simulated
+        moments for the visualization with estimagic should be returned. Data contains
+        the following columns:
+        - moment_column: Contains the column names of the moment DataFrames/Series
+        names.
+        - moment_index: Contains the index of the moment DataFrames/Series. MultiIndex
+        indices will be joined to one string.
+        - value: Contains moment values.
+        - moment_set: Indicator for each set of moments, will use keys if
+        empirical_moments are specified in a dict. Moments input as lists will
+        be numbered according to position.
+        - kind: Indicates whether moments are empirical or simulated.
     Returns
     -------
     msm_func: callable
@@ -126,7 +136,7 @@ def get_msm_func(
             "the number of sets of empirical moments."
         )
 
-    if return_moments and return_comparison_plot_data:
+    if return_moments and return_comparison_plot_data[0]:
         raise ValueError(
             "Can only return either moments or comparison plot data, not both."
         )

--- a/respy/method_of_simulated_moments.py
+++ b/respy/method_of_simulated_moments.py
@@ -415,6 +415,9 @@ def _create_tidy_data(data, plot_kinds):
 
 def _align_plot_kinds(data, plot_kinds):
     """Align input specifying the kinds of comparison plots with moments."""
+    if isinstance(plot_kinds, str):
+        plot_kinds = [plot_kinds]
+
     plot_kinds = _harmonize_input(plot_kinds)
 
     if 1 == len(plot_kinds) and 1 < len(data):

--- a/respy/method_of_simulated_moments.py
+++ b/respy/method_of_simulated_moments.py
@@ -75,7 +75,7 @@ def get_msm_func(
         Indicates whether moments should be returned with other output. If True will
         return a tuple of empirical_moments and simulated moments in list form.
     return_comparison_plot_data: bool, default False
-        Indicator for whether a :class:`pandas.DataFrame` with various contributions 
+        Indicator for whether a :class:`pandas.DataFrame` with various contributions
         for the visualization with estimagic should be returned.
     Returns
     -------
@@ -196,8 +196,8 @@ def msm(
     -------
     out : pandas.Series or float or tuple
         Scalar or moment error vector depending on value of return_scalar. Will be a
-        tuple containing a list of moments or a tidy DataFrame if either return_moments or 
-        the first element in return_comparison_plot_data is True.
+        tuple containing a list of moments or a tidy DataFrame if either return_moments
+        or the first element in return_comparison_plot_data is True.
 
     """
     empirical_moments = copy.deepcopy(empirical_moments)
@@ -370,7 +370,9 @@ def _flatten_index(data):
     return pd.concat(data_flat)
 
 
-def _create_comparison_plot_data_msm(empirical_moments, simulated_moments, moment_set_labels):
+def _create_comparison_plot_data_msm(
+    empirical_moments, simulated_moments, moment_set_labels
+):
     """Create pandas.DataFrame for estimagic's comparison plot."""
     if moment_set_labels is None:
         moment_set_labels = list(range(0, len(empirical_moments)))

--- a/respy/method_of_simulated_moments.py
+++ b/respy/method_of_simulated_moments.py
@@ -213,29 +213,24 @@ def msm(
     moment_errors = flat_empirical_moments - flat_simulated_moments
 
     # Return moment errors as indexed DataFrame or calculate weighted square product of
-    # moment errors depending on return_scalar. Also return moments in lists or as tidy
-    # data if specified.
+    # moment errors depending on return_scalar.
+    if return_scalar:
+        out = moment_errors.T @ weighting_matrix @ moment_errors
+    else:
+        out = moment_errors
+
+    # Return moments in lists or as tidy data if specified.
     if return_moments:
-        if return_scalar:
-            out = moment_errors.T @ weighting_matrix @ moment_errors
-            out = (out, (empirical_moments, simulated_moments))
-        else:
-            out = moment_errors
+        out = (out, (empirical_moments, simulated_moments))
 
     elif comparison_plot_kinds is not None:
         tidy_moments = _create_comparison_plot_data_msm(
             empirical_moments, simulated_moments, comparison_plot_kinds
         )
-        if return_scalar:
-            out = moment_errors.T @ weighting_matrix @ moment_errors
-            out = (out, tidy_moments)
-        else:
-            out = (moment_errors, tidy_moments)
+        out = (out, tidy_moments)
+
     else:
-        if return_scalar:
-            out = moment_errors.T @ weighting_matrix @ moment_errors
-        else:
-            out = moment_errors
+        pass
 
     return out
 

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -95,15 +95,15 @@ def test_randomness_msm(model_or_seed):
 
 
 @pytest.mark.integration
-def test_return_moments_for_msm(inputs):
+def test_return_simulated_moments_for_msm(inputs):
     """
-    Tests the return_moments functionality.
+    Tests the return_simulated_moments functionality.
     """
-    msm = get_msm_func(*inputs, return_moments=True)
-    fval, moments = msm(inputs[0])
+    msm = get_msm_func(*inputs, return_simulated_moments=True)
+    fval, simulated_moments = msm(inputs[0])
 
     assert isinstance(fval, float)
-    assert isinstance([moments, moments[0], moments[1]], list)
+    assert isinstance(simulated_moments, (dict, list, pd.DataFrame, pd.Series))
 
 
 @pytest.mark.integration
@@ -124,7 +124,9 @@ def test_multiple_returns_msm(inputs):
     Tests exception for when both moments and comparison plot data is selected.
     """
     with pytest.raises(Exception):
-        get_msm_func(*inputs, return_moments=True, return_comparison_plot_data=True)
+        get_msm_func(
+            *inputs, return_simulated_moments=True, return_comparison_plot_data=True
+        )
 
 
 def _calc_choice_freq(df):

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -96,9 +96,7 @@ def test_randomness_msm(model_or_seed):
 
 @pytest.mark.integration
 def test_return_simulated_moments_for_msm(inputs):
-    """
-    Return_simulated_moments.
-    """
+    """Return_simulated_moments."""
     msm = get_msm_func(*inputs, return_simulated_moments=True)
     fval, simulated_moments = msm(inputs[0])
 

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -97,7 +97,7 @@ def test_randomness_msm(model_or_seed):
 @pytest.mark.integration
 def test_return_simulated_moments_for_msm(inputs):
     """
-    Tests the return_simulated_moments functionality.
+    Return_simulated_moments.
     """
     msm = get_msm_func(*inputs, return_simulated_moments=True)
     fval, simulated_moments = msm(inputs[0])
@@ -108,9 +108,7 @@ def test_return_simulated_moments_for_msm(inputs):
 
 @pytest.mark.integration
 def test_return_comparison_plot_data_for_msm(inputs):
-    """
-    Tests the return_comparison_plot_data functionality.
-    """
+    """Return_comparison_plot_data."""
     msm = get_msm_func(*inputs, return_scalar=False, return_comparison_plot_data=True)
     moment_errors, df = msm(inputs[0])
 
@@ -120,10 +118,8 @@ def test_return_comparison_plot_data_for_msm(inputs):
 
 @pytest.mark.integration
 def test_multiple_returns_msm(inputs):
-    """
-    Tests exception for when both moments and comparison plot data is selected.
-    """
-    with pytest.raises(Exception):
+    """Raise error if moments and comparison plot data is requested."""
+    with pytest.raises(ValueError, match="Can only return either"):
         get_msm_func(
             *inputs, return_simulated_moments=True, return_comparison_plot_data=True
         )

--- a/respy/tests/test_method_of_simulated_moments.py
+++ b/respy/tests/test_method_of_simulated_moments.py
@@ -1,4 +1,5 @@
 """Test the msm interface of respy."""
+import pandas as pd
 import pytest
 
 from respy.interface import get_example_model
@@ -91,6 +92,39 @@ def test_randomness_msm(model_or_seed):
     )
 
     assert msm(params) == 0
+
+
+@pytest.mark.integration
+def test_return_moments_for_msm(inputs):
+    """
+    Tests the return_moments functionality.
+    """
+    msm = get_msm_func(*inputs, return_moments=True)
+    fval, moments = msm(inputs[0])
+
+    assert isinstance(fval, float)
+    assert isinstance([moments, moments[0], moments[1]], list)
+
+
+@pytest.mark.integration
+def test_return_comparison_plot_data_for_msm(inputs):
+    """
+    Tests the return_comparison_plot_data functionality.
+    """
+    msm = get_msm_func(*inputs, return_scalar=False, return_comparison_plot_data=True)
+    moment_errors, df = msm(inputs[0])
+
+    assert isinstance(moment_errors, pd.Series)
+    assert isinstance(df, pd.DataFrame)
+
+
+@pytest.mark.integration
+def test_multiple_returns_msm(inputs):
+    """
+    Tests exception for when both moments and comparison plot data is selected.
+    """
+    with pytest.raises(Exception):
+        get_msm_func(*inputs, return_moments=True, return_comparison_plot_data=True)
 
 
 def _calc_choice_freq(df):


### PR DESCRIPTION
### Current behavior/ Desired behavior

The msm function currently only returns a scalar or moment errors. For visualization and assessment of different parameter vectors, it would be convenient if the function could also return simulated and empirical moments.

The PR additionally tackles issue #317, which concerns the implementation of the comparison_plot_data feature i.e. allowing the msm function to return the moments in a tidy data format to pass on to estimagic.  

The way I set it up now, these features exclude each other i.e. the criterion function can return either the moments or the comparison plot data, not both.

### Solution / Implementation

1. **Returning moments**: The boolean argument `return_moments` will return a tuple of `empirical_moments` and `simulated_moments` in addition to the output chosen with `return_scalar`. The moments are currently returned in list form (at the point they are in before they are flattened) which might not be optimal. An alternative would be to return the flattened moment vectors (which might not be nice to work with though since the user would have to handle the flattened indexes) or  to try and return the moments in the form they were input as (which would require a lot of additional code and might become messy though). Opinions and suggestions are very welcome.

2. **comparison_plot_data**:  This feature is implemented through the ~~argument `comparison_plot_kinds` which takes a string, dictionary or list of the same form as `empirical_moments` as input~~ and returns a DataFrame in tidy data format. The returned DataFrame will have the following columns:
- **moment_column**: Contains the column names of the moment DataFrames/ Series names.
- **moment_index**:  Contains the index of the moment DataFrames/Series (usually Periods).
- **value**: Contains the moment values.
- ~~**kind**: Specifies the kind of plot that can be created from the input moments and should be of the same form as `empirical_moments`. I was thinking along the lines of what we discussed with potential visualizations in #360. Since there are basically no limits on what the moments could look like, it might be useful to require the user to specify what kind of plot should be created for a moment. I am not super clear on how estimagic actually processes the data, so this might not be useful at all. My idea is, that this functions as a tag that helps estimagic identify what type of plot should be created from the data for a set of moments.~~
- ~~**moment_set**: Indicator for the moment set, will be dictionary keys if `kind` is specified in a dict and will just be numbered otherwise.~~
- ~~**type**: Indicates whether moments are empirical or simulated.~~

~~In case specifying the **kind**  of plot for set of moments is not necessary, we can turn the argument in the criterion function into a boolean argument, which might be more user friendly.~~

-> **Update on part 2:** see comment below.

Closes #317.

### Todo
- [x] Figure out how to handle MultiIndex Series and DataFrames as inputs. 
- [x] Proof-reading, improve naming of variables.
- [x] Update msm article in documentation.
- [x] Document PR in CHANGES.rst.
