### PR TITLE
Fix shocks in simulated data

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python >=3.6
   run:
     - python >=3.6
-    - chaospy
+    - chaospy >=4.2.3
     - click
     - estimagic >=0.1.2
     - hypothesis

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python >=3.6
     - chaospy
     - click
-    - estimagic >=0.0.30
+    - estimagic >=0.1.2
     - hypothesis
     - joblib
     - fastparquet

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - python >=3.6
   run:
     - python >=3.6
-    - chaospy >=4.2.3
     - click
     - estimagic >=0.1.2
     - hypothesis

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.1
+    rev: v2.23.3
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.3
+    rev: v2.24.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/docs/about_us.rst
+++ b/docs/about_us.rst
@@ -68,7 +68,7 @@ an issue on Github, writing an `email`_ to or join our `zulipchat group
 
       |OSE| |space| |TRA| |space| |UniBonn| |space| |DIW|
 
-      .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-corporate-design/master/logos/OSE_logo_RGB.svg
+      .. |OSE| image::https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_Bonn_logo_RGB.svg
         :width: 20%
         :target: https://open-econ.org
 

--- a/docs/about_us.rst
+++ b/docs/about_us.rst
@@ -69,7 +69,7 @@ an issue on Github, writing an `email`_ to or join our `zulipchat group
       |OSE| |space| |TRA| |space| |UniBonn| |space| |DIW|
 
       .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_logo_no_type_RGB.svg
-        :width: 20%
+        :width: 10%
         :target: https://open-econ.org
 
       .. |UniBonn| image:: _static/images/UNI_Bonn_Logo_Standard_RZ_RGB.svg

--- a/docs/about_us.rst
+++ b/docs/about_us.rst
@@ -68,7 +68,7 @@ an issue on Github, writing an `email`_ to or join our `zulipchat group
 
       |OSE| |space| |TRA| |space| |UniBonn| |space| |DIW|
 
-      .. |OSE| image::https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_Bonn_logo_RGB.svg
+      .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_Bonn_logo_RGB.svg
         :width: 20%
         :target: https://open-econ.org
 

--- a/docs/about_us.rst
+++ b/docs/about_us.rst
@@ -68,7 +68,7 @@ an issue on Github, writing an `email`_ to or join our `zulipchat group
 
       |OSE| |space| |TRA| |space| |UniBonn| |space| |DIW|
 
-      .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_Bonn_logo_RGB.svg
+      .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_logo_no_type_RGB.svg
         :width: 20%
         :target: https://open-econ.org
 

--- a/docs/about_us.rst
+++ b/docs/about_us.rst
@@ -69,7 +69,7 @@ an issue on Github, writing an `email`_ to or join our `zulipchat group
       |OSE| |space| |TRA| |space| |UniBonn| |space| |DIW|
 
       .. |OSE| image:: https://raw.githubusercontent.com/OpenSourceEconomics/ose-logos/main/OSE_logo_no_type_RGB.svg
-        :width: 10%
+        :width: 20 %
         :target: https://open-econ.org
 
       .. |UniBonn| image:: _static/images/UNI_Bonn_Logo_Standard_RZ_RGB.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ copyright = f"2015-{dt.datetime.now().year}, The respy Development Team"  # noqa
 author = "The respy Development Team"
 
 # The full version, including alpha/beta/rc tags.
-release = "2.1.0"
+release = "2.1.1"
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,6 @@ html_logo = "_static/images/respy-logo.svg"
 
 
 html_sidebars = {
-    "index": ["sidebar-search-bs.html", "custom-intro.html"],
-    "about_us": ["sidebar-search-bs.html", "custom-about-us.html"],
+    "index": ["sidebar-search", "custom-intro"],
+    "about_us": ["sidebar-search", "custom-about-us"],
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,6 @@ html_logo = "_static/images/respy-logo.svg"
 
 
 html_sidebars = {
-    "index": ["sidebar-search", "custom-intro"],
-    "about_us": ["sidebar-search", "custom-about-us"],
+    "index": ["search-field", "custom-intro"],
+    "about_us": ["search-field", "custom-about-us"],
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,8 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3.8", None),
 }
 
+bibtex_bibfiles = ["explanations/refs.bib"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 html_static_path = ["_static"]

--- a/docs/how_to_guides/how_to_numerical_integration.ipynb
+++ b/docs/how_to_guides/how_to_numerical_integration.ipynb
@@ -2,28 +2,27 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Numerical Integration\n",
     "\n",
     "One important component of the solution to the DCDP problem in **respy** models is numerical integration. A bottleneck in solving and estimating the model is the solution of the expected value function, the so-called $EMax(\\cdot)$. Solving the $EMax(\\cdot)$ requires us to solve a multi-dimensional integral at every point in the state space. The integrated value function does not have an analytical solution and thus requires the application of numerical methods.\n",
     "\n",
     "As the models become more complex, the computational burden increases as adding new features to the model increases the required number of function evaluations, which are the costly operation in numerical integration. Numerical integration usually uses monte carlo simulation. Results from applied mathematics, however, suggest methods that are more efficient and thus enable a performance increase. For the same number of function evaluations (and hence computational cost) quasi-Monte Carlo methods achieve a significantly higher accuracy. **respy** thus enables users to select between various methods for the numerical approximation of the $EMax(\\cdot)$. The numerical integration is controlled in the `options` of a specified model.\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "import respy as rp\n",
+    "import respy as rp\r\n",
     "_, options = rp.get_example_model(\"kw_94_one\", with_data=False)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Numerical integration method\n",
     "\n",
@@ -31,95 +30,107 @@
     "\n",
     "- `random`: Points are drawn randomly (crude Monte Carlo).\n",
     "- `sobol` or `halton`: Points are drawn from low-discrepancy sequences (superiority in coverage). This means a given approximation error can be achieved with less points."
-   ]
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\r\n",
+    "**Note**: **respy** relies on [chaospy](https://chaospy.readthedocs.io/en/master) for the `sobol` and `halton` sequence. You need to install it in addition to **respy**.\r\n",
+    "</div>"
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "source": [
+    "options[\"monte_carlo_sequence\"]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "'random'"
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 3
     }
    ],
-   "source": [
-    "options[\"monte_carlo_sequence\"]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "## Solution draws\n",
-    "\n",
+    "## Solution draws\r\n",
+    "\r\n",
     "The number of solution draws controls how many points are used to evaluate an integral. You can specify them using the option `solution_draws`."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "source": [
+    "options[\"solution_draws\"]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "500"
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 4
     }
    ],
-   "source": [
-    "options[\"solution_draws\"]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Increasing the number of solution draws increases the accuracy of the solution at the cost of the computational burden."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "raw",
-   "metadata": {},
    "source": [
-    "<div class=\"d-flex flex-row gs-torefguide\">\n",
-    "    <span class=\"badge badge-info\">Project</span>\n",
-    "\n",
-    "    Find an exploration of numerical integration methods in   \n",
-    "    EKW models in <a\n",
-    "    href=\"../projects/numerical_integration.html\">Improving the Numerical Integration</a>.\n",
+    "<div class=\"d-flex flex-row gs-torefguide\">\r\n",
+    "    <span class=\"badge badge-info\">Project</span>\r\n",
+    "\r\n",
+    "    Find an exploration of numerical integration methods in   \r\n",
+    "    EKW models in <a\r\n",
+    "    href=\"../projects/numerical_integration.html\">Improving the Numerical Integration</a>.\r\n",
     "</div>"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.9.5 64-bit ('respy': conda)"
   },
   "language_info": {
+   "name": "python",
+   "version": "3.9.6",
+   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "interpreter": {
+   "hash": "b549dadab0c2edb1c58f223f7584f57e60f2cc8e65ef8392efb9b23cb30dad20"
   }
  },
  "nbformat": 4,

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -21,7 +21,8 @@ releases are available on `Anaconda.org
   (:ghuser:`MaxBlesch`, :ghuser:`amageh`).
 - :gh:`406` More information in example models guide (:ghuser:`carolinalvarez`, 
   :ghuser:`amageh`).
-- :gh:`414` Fix bug in simulate that added untransformed shocks to df (:ghuser:`amageh`).
+- :gh:`414` Fix bug in simulate that added untransformed shocks to df. Removes
+  chaospy from conda dependencies(:ghuser:`amageh`).
 
 
 2.0.0 - 2019-2020

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -21,6 +21,7 @@ releases are available on `Anaconda.org
   (:ghuser:`MaxBlesch`, :ghuser:`amageh`).
 - :gh:`406` More information in example models guide (:ghuser:`carolinalvarez`, 
   :ghuser:`amageh`).
+- :gh:`414` Fix bug in simulate that added untransformed shocks to df (:ghuser:`amageh`).
 
 
 2.0.0 - 2019-2020

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - sphinx
   - sphinx-autobuild
   - sphinx-autoapi
-  - sphinxcontrib-bibtex<2.0.0
-  - pydata-sphinx-theme<0.6.0
+  - sphinxcontrib-bibtex>=2.0.0
+  - pydata-sphinx-theme>=0.6.0
   - parso>=0.8.1
   - pip:
     - sphinx-tabs

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -112,7 +112,7 @@ you will find several cross-references to the theoretical concepts behind the mo
                         <div class="card-header">Exogenous Processes</div>
                         <div class="card-body flex-fill">
                             <p class="card-text">
-                                We introduce exogenous processes such as childrearing 
+                                We introduce exogenous processes such as child rearing 
                                     or health conditions to our model.
                             </p>
                         </div>

--- a/docs/tutorials/installation.rst
+++ b/docs/tutorials/installation.rst
@@ -47,6 +47,17 @@ path, installing **respy** is as simple as typing
 in a command shell. The whole package repository can be found under
 https://anaconda.org/OpenSourceEconomics/respy.
 
+
+If you want to use different numerical integration methods implemented in **respy** you
+also need to additionally install the package
+`chaospy <https://chaospy.readthedocs.io>`_ as it is not added automatically as a
+package dependency.
+
+.. code-block:: bash
+
+    $ pip install chaospy
+
+
 As **respy** relies heavily on ``pandas``, you might also want to install their
 `recommended dependencies <https://pandas.pydata.org/pandas-docs/stable/getting_started/
 install.html#recommended-dependencies>`_ to speed up internal calculations done with

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - anaconda-client
   - bottleneck
-  - chaospy>=4.2.3
   - click
   - codecov
   - conda-build
@@ -50,3 +49,4 @@ dependencies:
     - bump2version
     - pytest-randomly
     - sphinx-tabs
+    - chaospy>=4.2.3

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - conda-build
   - conda-verify
   - doc8
-  - estimagic>0.0.31
+  - estimagic>=0.1.2
   - fastparquet
   - hypothesis
   - joblib

--- a/environment.yml
+++ b/environment.yml
@@ -41,9 +41,9 @@ dependencies:
   - snakeviz
   - sphinx
   - sphinx-autobuild
-  - sphinxcontrib-bibtex<2.0.0
+  - sphinxcontrib-bibtex>=2.0.0
   - sphinx-autoapi
-  - pydata-sphinx-theme>=0.3.0
+  - pydata-sphinx-theme>=0.6.0
   - tox-conda
   - pip:
     - apprise

--- a/environment.yml
+++ b/environment.yml
@@ -7,13 +7,13 @@ dependencies:
   - pip
   - anaconda-client
   - bottleneck
-  - chaospy
+  - chaospy>=4.2.3
   - click
   - codecov
   - conda-build
   - conda-verify
   - doc8
-  - estimagic>=0.0.30
+  - estimagic>0.0.31
   - fastparquet
   - hypothesis
   - joblib

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - numexpr
   - numpydoc
   - pandas>=0.24
-  - numpy>=1.2
+  - numpy>=1.21.0
   - pdbpp
   - pre-commit
   - pyarrow

--- a/respy/__init__.py
+++ b/respy/__init__.py
@@ -35,7 +35,7 @@ __all__ = [
     "add_noise_to_params",
 ]
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 
 def test(*args, **kwargs):

--- a/respy/config.py
+++ b/respy/config.py
@@ -3,6 +3,14 @@ from pathlib import Path
 
 import numpy as np
 
+# Check if chaospy is installed.
+try:
+    import chaospy  # noqa
+except ImportError:
+    CHAOSPY_INSTALLED = False
+else:
+    CHAOSPY_INSTALLED = True
+
 # Obtain the root directory of the package. Do not import respy which creates a circular
 # import.
 ROOT_DIR = Path(__file__).parent
@@ -58,7 +66,7 @@ DEFAULT_OPTIONS = {
     "solution_seed": 3,
     "core_state_space_filters": [],
     "negative_choice_set": {},
-    "monte_carlo_sequence": "sobol",
+    "monte_carlo_sequence": "random",
     "cache_compression": "snappy",
 }
 

--- a/respy/method_of_simulated_moments.py
+++ b/respy/method_of_simulated_moments.py
@@ -292,6 +292,8 @@ def get_diag_weighting_matrix(empirical_moments, weights=None):
         }
 
         flat_weights = _flatten_index(weights)
+        flat_empirical_moments = _flatten_index(empirical_moments)
+        flat_weights = flat_weights.reindex_like(flat_empirical_moments)
 
     return np.diag(flat_weights)
 
@@ -369,10 +371,10 @@ def _flatten_index(moments):
     pandas.DataFrame
 
     """
-    moments = copy.deepcopy(moments)
     data_flat = []
 
     for name, series_or_df in moments.items():
+        series_or_df = series_or_df.copy(deep=True)
         series_or_df.index = series_or_df.index.map(str)
         # Unstack pandas.DataFrames and pandas.Series to add
         # columns/name to index.

--- a/respy/shared.py
+++ b/respy/shared.py
@@ -114,11 +114,11 @@ def create_base_draws(shape, seed, monte_carlo_sequence):
         draws = np.random.standard_normal(shape)
 
     elif monte_carlo_sequence == "halton":
-        distribution = cp.MvNormal(loc=np.zeros(n_choices), scale=np.eye(n_choices))
+        distribution = cp.MvNormal(mu=np.zeros(n_choices), sigma=np.eye(n_choices))
         draws = distribution.sample(n_points, rule="H").T.reshape(shape)
 
     elif monte_carlo_sequence == "sobol":
-        distribution = cp.MvNormal(loc=np.zeros(n_choices), scale=np.eye(n_choices))
+        distribution = cp.MvNormal(mu=np.zeros(n_choices), sigma=np.eye(n_choices))
         draws = distribution.sample(n_points, rule="S").T.reshape(shape)
 
     else:

--- a/respy/shared.py
+++ b/respy/shared.py
@@ -6,15 +6,18 @@ import from respy itself. This is to prevent circular imports.
 """
 import shutil
 
-import chaospy as cp
 import numba as nb
 import numpy as np
 import pandas as pd
 
 from respy._numba import array_to_tuple
+from respy.config import CHAOSPY_INSTALLED
 from respy.config import MAX_LOG_FLOAT
 from respy.config import MIN_LOG_FLOAT
 from respy.parallelization import parallelize_across_dense_dimensions
+
+if CHAOSPY_INSTALLED:
+    import chaospy as cp
 
 
 @nb.njit
@@ -109,18 +112,19 @@ def create_base_draws(shape, seed, monte_carlo_sequence):
     n_points = np.prod(shape[:-1])
 
     np.random.seed(seed)
-
     if monte_carlo_sequence == "random":
         draws = np.random.standard_normal(shape)
 
-    elif monte_carlo_sequence == "halton":
-        distribution = cp.MvNormal(mu=np.zeros(n_choices), sigma=np.eye(n_choices))
-        draws = distribution.sample(n_points, rule="H").T.reshape(shape)
-
-    elif monte_carlo_sequence == "sobol":
-        distribution = cp.MvNormal(mu=np.zeros(n_choices), sigma=np.eye(n_choices))
-        draws = distribution.sample(n_points, rule="S").T.reshape(shape)
-
+    elif monte_carlo_sequence in ["sobol", "halton"]:
+        if CHAOSPY_INSTALLED:
+            rule = monte_carlo_sequence[0].capitalize()
+            distribution = cp.MvNormal(mu=np.zeros(n_choices), sigma=np.eye(n_choices))
+            draws = distribution.sample(n_points, rule=rule).T.reshape(shape)
+        else:
+            raise ImportError(
+                "Install the package chaospy to use 'sobol' and 'halton' "
+                "in options['monte_carlo_sequence']."
+            )
     else:
         raise NotImplementedError
 

--- a/respy/simulate.py
+++ b/respy/simulate.py
@@ -447,6 +447,7 @@ def _simulate_single_period(
         df[f"flow_utility_{choice}"] = flow_utilities[:, i]
         df[f"value_function_{choice}"] = value_functions[:, i]
         df[f"continuation_value_{choice}"] = continuation_values[:, i]
+        df[f"shock_reward_{choice}"] = draws_shock_transformed[:, i]
 
     # Check if there is an exogenous process
     if optim_paras["exogenous_processes"]:

--- a/respy/tests/test_solve.py
+++ b/respy/tests/test_solve.py
@@ -277,6 +277,7 @@ def test_dense_choice_cores():
     point_constr = {"n_periods": 6, "observables": [3], "n_lagged_choices": 1}
 
     params, options = generate_random_model(point_constr=point_constr)
+    options["monte_carlo_sequence"] = "sobol"
 
     # Add some inadmissible states
     optim_paras, _ = process_params_and_options(params, options)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ PROJECT_URLS = {
 
 setup(
     name="respy",
-    version="2.1.0",
+    version="2.1.1",
     description=DESCRIPTION,
     long_description=DESCRIPTION + "\n\n" + README,
     long_description_content_type="text/x-rst",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
 conda_deps =
     bottleneck
-    chaospy >= 4.2.3
     click
     codecov
     conda-build
@@ -38,6 +37,7 @@ conda_channels =
 deps =
     apprise
     pytest-randomly
+    chaospy >= 4.2.3
 commands =
     pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
 conda_deps =
     bottleneck
-    chaospy >=4.2.3
+    chaospy >= 4.2.3
     click
     codecov
     conda-build
@@ -60,10 +60,10 @@ conda_deps =
     nbsphinx
     numpydoc
     sphinx
-    sphinxcontrib-bibtex<2.0.0
+    sphinxcontrib-bibtex>=2.0.0
     sphinx-autoapi
     sphinx-tabs
-    pydata-sphinx-theme<0.6.0
+    pydata-sphinx-theme>=0.6.0
 conda_channels =
     conda-forge
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ setenv =
     CONDA_DLL_SEARCH_MODIFICATION_ENABLE = 1
 conda_deps =
     bottleneck
-    chaospy
-    click >=4.2.3
+    chaospy >=4.2.3
+    click
     codecov
     conda-build
     estimagic >= 0.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ conda_deps =
     mkl
     numba
     numexpr
-    numpy >=1.2
+    numpy >=1.21.0
     pandas >= 0.24
     scipy
     pyaml

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ setenv =
 conda_deps =
     bottleneck
     chaospy
-    click
+    click >=4.2.3
     codecov
     conda-build
-    estimagic >= 0.0.30
+    estimagic >= 0.1.2
     fastparquet
     hypothesis
     joblib


### PR DESCRIPTION
This PR fixes a bug in simulate which only adds untransformed shocks to df. Changes listed below:

### Todo

- [x]  Make respy compatibale with newer chaospy versions (conda installations for chaospy only go to 3.3.8 which means newer versions need to be installed via pip, as a workaround I suggest requiring chaospy to be installed manually as it is only used with the sobol and halton sequence and therefore not of central relevance to respy).
- [x] Fix broken link to OSE logo in documentation.
- [x] Bump respy version.
- [x] Fix bug in shocks in simulate.py + add test.
- [x] Fix some bugs in msm interface. 
- [x] Review whether the documentation needs to be updated.
- [x] Document PR in release_notes.rst.
